### PR TITLE
Format the codebase

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ script:
   - mix coveralls.safe_travis
   - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
   - mix credo --strict
+  - mix format --check-formatted
 
 after_script:
   - mix deps.get --only docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
   - mix coveralls.safe_travis
   - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
   - mix credo --strict
-  - if [ ${WALLABY_CHECK_FORMATTING == 'true' ]; then mix format --check-formatted; fi
+  - if [ ${WALLABY_CHECK_FORMATTING} == 'true' ]; then mix format --check-formatted; fi
 
 after_script:
   - mix deps.get --only docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
     env: WALLABY_DRIVER=selenium
   - elixir: 1.9.1
     otp_release: 22.0.7
-    env: ""
+    env: "WALLABY_CHECK_FORMATTING=true"
   - elixir: 1.9.1
     otp_release: 22.0.7
     env: WALLABY_DRIVER=phantom
@@ -92,7 +92,7 @@ script:
   - mix coveralls.safe_travis
   - if [ -z ${WALLABY_DRIVER} ]; then mix dialyzer --halt-exit-status; fi # only run dialyzer for the env without drivers
   - mix credo --strict
-  - mix format --check-formatted
+  - if [ ${WALLABY_CHECK_FORMATTING == 'true' ]; then mix format --check-formatted; fi
 
 after_script:
   - mix deps.get --only docs

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,4 +35,4 @@ config :wallaby,
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -32,8 +32,8 @@ defmodule Wallaby do
     children = [
       supervisor(Wallaby.Driver.ProcessWorkspace.ServerSupervisor, []),
       supervisor(driver(), [[name: Wallaby.Driver.Supervisor]]),
-      :hackney_pool.child_spec(:wallaby_pool, [timeout: 15_000, max_connections: 4]),
-      worker(Wallaby.SessionStore, []),
+      :hackney_pool.child_spec(:wallaby_pool, timeout: 15_000, max_connections: 4),
+      worker(Wallaby.SessionStore, [])
     ]
 
     opts = [strategy: :one_for_one, name: Wallaby.Supervisor]
@@ -74,21 +74,21 @@ defmodule Wallaby do
   end
   ```
   """
-  @spec start_session([start_session_opts]) :: {:ok, Session.t} | {:error, reason}
+  @spec start_session([start_session_opts]) :: {:ok, Session.t()} | {:error, reason}
   def start_session(opts \\ []) do
     with {:ok, session} <- driver().start_session(opts),
          :ok <- SessionStore.monitor(session),
-      do: {:ok, session}
+         do: {:ok, session}
   end
 
   @doc """
   Ends a browser session.
   """
-  @spec end_session(Session.t) :: :ok | {:error, reason}
+  @spec end_session(Session.t()) :: :ok | {:error, reason}
   def end_session(%Session{driver: driver} = session) do
     with :ok <- SessionStore.demonitor(session),
          :ok <- driver.end_session(session),
-      do: :ok
+         do: :ok
   end
 
   @doc false
@@ -115,10 +115,13 @@ defmodule Wallaby do
     case System.get_env("WALLABY_DRIVER") do
       "chrome" ->
         Wallaby.Experimental.Chrome
+
       "selenium" ->
         Wallaby.Experimental.Selenium
+
       "phantom" ->
         Wallaby.Phantom
+
       _ ->
         Application.get_env(:wallaby, :driver, Wallaby.Phantom)
     end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -114,14 +114,16 @@ defmodule Wallaby.Browser do
 
   @type t :: any()
 
-  @opaque session :: Session.t
-  @opaque element :: Element.t
-  @opaque queryable :: Query.t
-                     | Element.t
+  @opaque session :: Session.t()
+  @opaque element :: Element.t()
+  @opaque queryable ::
+            Query.t()
+            | Element.t()
 
-  @type parent :: element
-                | session
-  @type locator :: String.t
+  @type parent ::
+          element
+          | session
+  @type locator :: String.t()
   @type opts :: Query.opts()
 
   @default_max_wait_time 3_000
@@ -146,10 +148,13 @@ defmodule Wallaby.Browser do
     case f.() do
       {:ok, result} ->
         {:ok, result}
+
       {:error, :stale_reference} ->
         retry(f, start_time)
+
       {:error, :invalid_selector} ->
         {:error, :invalid_selector}
+
       {:error, e} ->
         if max_time_exceeded?(start_time) do
           {:error, e}
@@ -176,17 +181,17 @@ defmodule Wallaby.Browser do
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.
   """
-  @spec fill_in(parent, Query.t, with: String.t) :: parent
+  @spec fill_in(parent, Query.t(), with: String.t()) :: parent
   def fill_in(parent, query, with: value) do
     parent
-    |> find(query, &(Element.fill_in(&1, with: value)))
+    |> find(query, &Element.fill_in(&1, with: value))
   end
 
   # @doc """
   # Clears an input field. Input elements are looked up by id, label text, or name.
   # The element can also be passed in directly.
   # """
-  @spec clear(parent, Query.t) :: parent
+  @spec clear(parent, Query.t()) :: parent
 
   def clear(parent, query) do
     parent
@@ -197,7 +202,7 @@ defmodule Wallaby.Browser do
   Attaches a file to a file input. Input elements are looked up by id, label text,
   or name.
   """
-  @spec attach_file(parent, Query.t, path: String.t) :: parent
+  @spec attach_file(parent, Query.t(), path: String.t()) :: parent
 
   def attach_file(parent, query, path: path) do
     parent
@@ -212,7 +217,7 @@ defmodule Wallaby.Browser do
   Pass `[{:name, "some_name"}]` to specify the file name. Defaults to a timestamp.
   Pass `[{:log, true}]` to log the location of the screenshot to stdout. Defaults to false.
   """
-  @type take_screenshot_opt :: {:name, String.t} | {:log, boolean}
+  @type take_screenshot_opt :: {:name, String.t()} | {:log, boolean}
   @spec take_screenshot(parent, [take_screenshot_opt]) :: parent
 
   def take_screenshot(%{driver: driver} = screenshotable, opts \\ []) do
@@ -220,12 +225,12 @@ defmodule Wallaby.Browser do
       screenshotable
       |> driver.take_screenshot
 
-    name = opts |> Keyword.get(:name, :erlang.system_time) |> to_string
+    name = opts |> Keyword.get(:name, :erlang.system_time()) |> to_string
     path = path_for_screenshot(name)
-    File.write! path, image_data
+    File.write!(path, image_data)
 
     if opts[:log] do
-      IO.puts "Screenshot taken, find it at file:///#{path}"
+      IO.puts("Screenshot taken, find it at file:///#{path}")
     end
 
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
@@ -234,7 +239,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the window handle of the currently focused window.
   """
-  @spec window_handle(parent) :: String.t
+  @spec window_handle(parent) :: String.t()
 
   def window_handle(%{driver: driver} = session) do
     {:ok, handle} = driver.window_handle(session)
@@ -244,7 +249,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the window handles of all available windows.
   """
-  @spec window_handles(parent) :: [String.t]
+  @spec window_handles(parent) :: [String.t()]
 
   def window_handles(%{driver: driver} = session) do
     {:ok, handles} = driver.window_handles(session)
@@ -254,7 +259,7 @@ defmodule Wallaby.Browser do
   @doc """
   Changes the driver focus to the window identified by the handle.
   """
-  @spec focus_window(parent, String.t) :: parent
+  @spec focus_window(parent, String.t()) :: parent
 
   def focus_window(%{driver: driver} = session, window_handle) do
     {:ok, _} = driver.focus_window(session, window_handle)
@@ -274,7 +279,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the size of the currently focused window.
   """
-  @spec window_size(parent) :: %{String.t => pos_integer, String.t => pos_integer}
+  @spec window_size(parent) :: %{String.t() => pos_integer, String.t() => pos_integer}
 
   def window_size(%{driver: driver} = session) do
     {:ok, size} = driver.get_window_size(session)
@@ -306,7 +311,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the position of the currently focused window.
   """
-  @spec window_position(parent) :: %{String.t => pos_integer, String.t => pos_integer}
+  @spec window_position(parent) :: %{String.t() => pos_integer, String.t() => pos_integer}
 
   def window_position(%{driver: driver} = session) do
     {:ok, position} = driver.get_window_position(session)
@@ -326,7 +331,7 @@ defmodule Wallaby.Browser do
   @doc """
   Changes the driver focus to the frame found by query.
   """
-  @spec focus_frame(parent,  Query.t) :: parent
+  @spec focus_frame(parent, Query.t()) :: parent
 
   def focus_frame(%{driver: driver} = session, %Query{} = query) do
     session
@@ -356,7 +361,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the current url of the session
   """
-  @spec current_url(parent) :: String.t
+  @spec current_url(parent) :: String.t()
 
   def current_url(%Session{driver: driver} = session) do
     {:ok, url} = driver.current_url(session)
@@ -366,7 +371,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the current path of the session
   """
-  @spec current_path(parent) :: String.t
+  @spec current_path(parent) :: String.t()
 
   def current_path(%Session{driver: driver} = session) do
     {:ok, path} = driver.current_path(session)
@@ -376,7 +381,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the title for the current page
   """
-  @spec page_title(parent) :: String.t
+  @spec page_title(parent) :: String.t()
 
   def page_title(%Session{driver: driver} = session) do
     {:ok, title} = driver.page_title(session)
@@ -388,23 +393,25 @@ defmodule Wallaby.Browser do
   an optional list of arguments available in the script via `arguments`, and an
   optional callback function with the result of script execution as a parameter.
   """
-  @spec execute_script(parent, String.t) :: parent
-  @spec execute_script(parent, String.t, list) :: parent
-  @spec execute_script(parent, String.t, ((binary()) -> any())) :: parent
-  @spec execute_script(parent, String.t, list, ((binary()) -> any())) :: parent
+  @spec execute_script(parent, String.t()) :: parent
+  @spec execute_script(parent, String.t(), list) :: parent
+  @spec execute_script(parent, String.t(), (binary() -> any())) :: parent
+  @spec execute_script(parent, String.t(), list, (binary() -> any())) :: parent
 
   def execute_script(session, script) do
     execute_script(session, script, [])
   end
 
   def execute_script(session, script, arguments) when is_list(arguments) do
-    execute_script(session, script, arguments, fn(_) -> nil end)
+    execute_script(session, script, arguments, fn _ -> nil end)
   end
+
   def execute_script(session, script, callback) when is_function(callback) do
     execute_script(session, script, [], callback)
   end
 
-  def execute_script(%{driver: driver} = parent, script, arguments, callback) when is_list(arguments) and is_function(callback) do
+  def execute_script(%{driver: driver} = parent, script, arguments, callback)
+      when is_list(arguments) and is_function(callback) do
     {:ok, value} = driver.execute_script(parent, script, arguments)
     callback.(value)
     parent
@@ -415,24 +422,25 @@ defmodule Wallaby.Browser do
   an optional list of arguments available in the script via `arguments`, and an
   optional callback function with the result of script execution as a parameter.
   """
-  @spec execute_script_async(parent, String.t) :: parent
-  @spec execute_script_async(parent, String.t, list) :: parent
-  @spec execute_script_async(parent, String.t, ((binary()) -> any())) :: parent
-  @spec execute_script_async(parent, String.t, list, ((binary()) -> any())) :: parent
+  @spec execute_script_async(parent, String.t()) :: parent
+  @spec execute_script_async(parent, String.t(), list) :: parent
+  @spec execute_script_async(parent, String.t(), (binary() -> any())) :: parent
+  @spec execute_script_async(parent, String.t(), list, (binary() -> any())) :: parent
 
   def execute_script_async(session, script) do
     execute_script_async(session, script, [])
   end
 
   def execute_script_async(session, script, arguments) when is_list(arguments) do
-    execute_script_async(session, script, arguments, fn(_) -> nil end)
+    execute_script_async(session, script, arguments, fn _ -> nil end)
   end
 
   def execute_script_async(session, script, callback) when is_function(callback) do
     execute_script_async(session, script, [], callback)
   end
 
-  def execute_script_async(%{driver: driver} = parent, script, arguments, callback) when is_list(arguments) and is_function(callback) do
+  def execute_script_async(%{driver: driver} = parent, script, arguments, callback)
+      when is_list(arguments) and is_function(callback) do
     {:ok, value} = driver.execute_script_async(parent, script, arguments)
     callback.(value)
     parent
@@ -458,15 +466,16 @@ defmodule Wallaby.Browser do
 
   Using JavaScript is a known workaround for filling in fields with Emojis and other non-BMP characters.
   """
-  @spec send_keys(parent, Query.t, Element.keys_to_send) :: parent
-  @spec send_keys(parent, Element.keys_to_send) :: parent
+  @spec send_keys(parent, Query.t(), Element.keys_to_send()) :: parent
+  @spec send_keys(parent, Element.keys_to_send()) :: parent
 
   def send_keys(parent, query, list) do
-    find(parent, query, fn(element) ->
+    find(parent, query, fn element ->
       element
       |> Element.send_keys(list)
     end)
   end
+
   def send_keys(%Element{} = element, keys) do
     Element.send_keys(element, keys)
   end
@@ -474,6 +483,7 @@ defmodule Wallaby.Browser do
   def send_keys(parent, keys) when is_binary(keys) do
     send_keys(parent, [keys])
   end
+
   def send_keys(%{driver: driver} = parent, keys) when is_list(keys) do
     {:ok, _} = driver.send_keys(parent, keys)
     parent
@@ -482,7 +492,7 @@ defmodule Wallaby.Browser do
   @doc """
   Retrieves the source of the current page.
   """
-  @spec page_source(parent) :: String.t
+  @spec page_source(parent) :: String.t()
 
   def page_source(%Session{driver: driver} = session) do
     {:ok, source} = driver.page_source(session)
@@ -496,28 +506,28 @@ defmodule Wallaby.Browser do
   * :selected for a radio button, checkbox or select list option
   * :unselected for a checkbox
   """
-  @spec set_value(parent, Query.t, Element.value) :: parent
+  @spec set_value(parent, Query.t(), Element.value()) :: parent
 
   def set_value(parent, query, :selected) do
-    find(parent, query, fn(element) ->
+    find(parent, query, fn element ->
       case Element.selected?(element) do
-        true    ->  :ok
-        false   ->  Element.click(element)
+        true -> :ok
+        false -> Element.click(element)
       end
     end)
   end
 
   def set_value(parent, query, :unselected) do
-    find(parent, query, fn(element) ->
+    find(parent, query, fn element ->
       case Element.selected?(element) do
-        false   ->  :ok
-        true    ->  Element.click(element)
+        false -> :ok
+        true -> Element.click(element)
       end
     end)
   end
 
   def set_value(parent, query, value) do
-    find(parent, query, fn(element) ->
+    find(parent, query, fn element ->
       element
       |> Element.set_value(value)
     end)
@@ -538,7 +548,7 @@ defmodule Wallaby.Browser do
   @doc """
   Clicks an element.
   """
-  @spec click(parent, Query.t) :: parent
+  @spec click(parent, Query.t()) :: parent
 
   def click(parent, query) do
     parent
@@ -584,7 +594,7 @@ defmodule Wallaby.Browser do
   @doc """
   Hovers over an element.
   """
-  @spec hover(parent, Query.t) :: parent
+  @spec hover(parent, Query.t()) :: parent
 
   def hover(parent, query) do
     parent
@@ -608,14 +618,15 @@ defmodule Wallaby.Browser do
 
   If the element is not visible, the return value will be `""`.
   """
-  @spec text(parent) :: String.t
-  @spec text(parent, Query.t) :: String.t
+  @spec text(parent) :: String.t()
+  @spec text(parent, Query.t()) :: String.t()
 
   def text(parent, query) do
     parent
     |> find(query)
-    |> Element.text
+    |> Element.text()
   end
+
   def text(%Session{} = session) do
     session
     |> find(Query.css("body"))
@@ -625,7 +636,7 @@ defmodule Wallaby.Browser do
   @doc """
   Gets the value of the elements attribute.
   """
-  @spec attr(parent, Query.t, String.t) :: String.t | nil
+  @spec attr(parent, Query.t(), String.t()) :: String.t() | nil
 
   def attr(parent, query, name) do
     parent
@@ -636,18 +647,18 @@ defmodule Wallaby.Browser do
   @doc """
   Checks if the element has been selected. Alias for checked?(element)
   """
-  @spec selected?(parent, Query.t) :: boolean()
+  @spec selected?(parent, Query.t()) :: boolean()
 
   def selected?(parent, query) do
     parent
     |> find(query)
-    |> Element.selected?
+    |> Element.selected?()
   end
 
   @doc """
   Checks if the element is visible on the page
   """
-  @spec visible?(parent, Query.t) :: boolean()
+  @spec visible?(parent, Query.t()) :: boolean()
 
   def visible?(parent, query) do
     parent
@@ -666,25 +677,26 @@ defmodule Wallaby.Browser do
   By default finders only work with elements that would be visible to a real
   user.
   """
-  @spec find(parent, Query.t, ((Element.t) -> any())) :: parent
-  @spec find(parent, Query.t) :: Element.t | [Element.t]
-  @spec find(parent, locator) :: Element.t | [Element.t]
+  @spec find(parent, Query.t(), (Element.t() -> any())) :: parent
+  @spec find(parent, Query.t()) :: Element.t() | [Element.t()]
+  @spec find(parent, locator) :: Element.t() | [Element.t()]
 
   def find(parent, %Query{} = query, callback) when is_function(callback) do
     results = find(parent, query)
     callback.(results)
     parent
   end
+
   def find(parent, %Query{} = query) do
     case execute_query(parent, query) do
       {:ok, query} ->
         query
-        |> Query.result
+        |> Query.result()
 
       {:error, {:not_found, result}} ->
         query = %Query{query | result: result}
 
-        if Wallaby.screenshot_on_failure? do
+        if Wallaby.screenshot_on_failure?() do
           take_screenshot(parent, log: true)
         end
 
@@ -697,7 +709,7 @@ defmodule Wallaby.Browser do
         end
 
       {:error, e} ->
-        if Wallaby.screenshot_on_failure? do
+        if Wallaby.screenshot_on_failure?() do
           take_screenshot(parent, log: true)
         end
 
@@ -710,19 +722,20 @@ defmodule Wallaby.Browser do
   found then an empty list is immediately returned. This is equivalent to calling
   `find(session, css("element", count: nil, minimum: 0))`.
   """
-  @spec all(parent, Query.t) :: [Element.t]
+  @spec all(parent, Query.t()) :: [Element.t()]
 
   def all(parent, %Query{} = query) do
     find(
       parent,
-      %Query{query | conditions: Keyword.merge(query.conditions, [count: nil, minimum: 0])})
+      %Query{query | conditions: Keyword.merge(query.conditions, count: nil, minimum: 0)}
+    )
   end
 
   @doc """
   Validates that the query returns a result. This can be used to define other
   types of matchers.
   """
-  @spec has?(parent, Query.t) :: boolean()
+  @spec has?(parent, Query.t()) :: boolean()
 
   def has?(parent, query) do
     case execute_query(parent, query) do
@@ -734,26 +747,29 @@ defmodule Wallaby.Browser do
   @doc """
   Matches the Element's value with the provided value.
   """
-  @spec has_value?(parent, Query.t, any()) :: boolean()
-  @spec has_value?(Element.t, any()) :: boolean()
+  @spec has_value?(parent, Query.t(), any()) :: boolean()
+  @spec has_value?(Element.t(), any()) :: boolean()
 
   def has_value?(parent, query, value) do
     parent
     |> find(query)
     |> has_value?(value)
   end
+
   def has_value?(%Element{} = element, value) do
-    result = retry fn ->
-      if Element.value(element) == value do
-        {:ok, true}
-      else
-        {:error, false}
-      end
-    end
+    result =
+      retry(fn ->
+        if Element.value(element) == value do
+          {:ok, true}
+        else
+          {:error, false}
+        end
+      end)
 
     case result do
       {:ok, true} ->
         true
+
       {:error, false} ->
         false
     end
@@ -762,31 +778,35 @@ defmodule Wallaby.Browser do
   @doc """
   Matches the Element's content with the provided text
   """
-  @spec has_text?(Element.t, String.t) :: boolean()
-  @spec has_text?(parent, Query.t, String.t) :: boolean()
+  @spec has_text?(Element.t(), String.t()) :: boolean()
+  @spec has_text?(parent, Query.t(), String.t()) :: boolean()
 
   def has_text?(parent, query, text) do
     parent
     |> find(query)
     |> has_text?(text)
   end
+
   def has_text?(%Session{} = session, text) when is_binary(text) do
     session
     |> find(Query.css("body"))
     |> has_text?(text)
   end
+
   def has_text?(parent, text) when is_binary(text) do
-    result = retry fn ->
-      if Element.text(parent) =~ text do
-        {:ok, true}
-      else
-        {:error, false}
-      end
-    end
+    result =
+      retry(fn ->
+        if Element.text(parent) =~ text do
+          {:ok, true}
+        else
+          {:error, false}
+        end
+      end)
 
     case result do
       {:ok, true} ->
         true
+
       {:error, false} ->
         false
     end
@@ -795,14 +815,15 @@ defmodule Wallaby.Browser do
   @doc """
   Matches the Element's content with the provided text and raises if not found
   """
-  @spec assert_text(Element.t, String.t) :: boolean()
-  @spec assert_text(parent, Query.t, String.t) :: boolean()
+  @spec assert_text(Element.t(), String.t()) :: boolean()
+  @spec assert_text(parent, Query.t(), String.t()) :: boolean()
 
   def assert_text(parent, query, text) when is_binary(text) do
     parent
     |> find(query)
     |> assert_text(text)
   end
+
   def assert_text(parent, text) when is_binary(text) do
     has_text?(parent, text) || raise ExpectationNotMetError, "Text '#{text}' was not found."
   end
@@ -823,26 +844,32 @@ defmodule Wallaby.Browser do
   defmacro assert_has(parent, query) do
     quote do
       parent = unquote(parent)
-      query  = unquote(query)
+      query = unquote(query)
 
       with {:ok, _query_result} <- execute_query(parent, query) do
         parent
       else
         error ->
-          if Wallaby.screenshot_on_failure? do
+          if Wallaby.screenshot_on_failure?() do
             take_screenshot(parent, log: true)
           end
+
           case error do
             {:error, {:not_found, results}} ->
               query = %Query{query | result: results}
+
               raise ExpectationNotMetError,
                     Query.ErrorMessage.message(query, :not_found)
+
             {:error, :invalid_selector} ->
               raise Wallaby.QueryError,
-                Query.ErrorMessage.message(query, :invalid_selector)
+                    Query.ErrorMessage.message(query, :invalid_selector)
+
             _ ->
               raise Wallaby.ExpectationNotMetError,
-                "Wallaby has encountered an internal error: #{inspect error} with session: #{inspect parent}"
+                    "Wallaby has encountered an internal error: #{inspect(error)} with session: #{
+                      inspect(parent)
+                    }"
           end
       end
     end
@@ -864,11 +891,12 @@ defmodule Wallaby.Browser do
   defmacro refute_has(parent, query) do
     quote do
       parent = unquote(parent)
-      query  = unquote(query)
+      query = unquote(query)
 
       case execute_query(parent, query) do
         {:error, _not_found} ->
           parent
+
         {:ok, query} ->
           raise Wallaby.ExpectationNotMetError,
                 Query.ErrorMessage.message(query, :found)
@@ -879,7 +907,7 @@ defmodule Wallaby.Browser do
   @doc """
   Searches for CSS on the page.
   """
-  @spec has_css?(parent, Query.t, String.t) :: boolean()
+  @spec has_css?(parent, Query.t(), String.t()) :: boolean()
   @spec has_css?(parent, locator) :: boolean()
 
   def has_css?(parent, query, css) when is_binary(css) do
@@ -887,16 +915,17 @@ defmodule Wallaby.Browser do
     |> find(query)
     |> has?(Query.css(css, count: :any))
   end
+
   def has_css?(parent, css) when is_binary(css) do
     parent
     |> find(Query.css(css, count: :any))
-    |> Enum.any?
+    |> Enum.any?()
   end
 
   @doc """
   Searches for css that should not be on the page
   """
-  @spec has_no_css?(parent, Query.t, String.t) :: boolean()
+  @spec has_no_css?(parent, Query.t(), String.t()) :: boolean()
   @spec has_no_css?(parent, locator) :: boolean()
 
   def has_no_css?(parent, query, css) when is_binary(css) do
@@ -904,6 +933,7 @@ defmodule Wallaby.Browser do
     |> find(query)
     |> has?(Query.css(css, count: 0))
   end
+
   def has_no_css?(parent, css) when is_binary(css) do
     parent
     |> has?(Query.css(css, count: 0))
@@ -914,7 +944,7 @@ defmodule Wallaby.Browser do
   Relative paths are appended to the provided base_url.
   Absolute paths do not use the base_url.
   """
-  @spec visit(session, String.t) :: session
+  @spec visit(session, String.t()) :: session
 
   def visit(%Session{driver: driver} = session, path) do
     uri = URI.parse(path)
@@ -922,8 +952,10 @@ defmodule Wallaby.Browser do
     cond do
       uri.host == nil && String.length(base_url()) == 0 ->
         raise NoBaseUrlError, path
+
       uri.host ->
         driver.visit(session, path)
+
       true ->
         driver.visit(session, request_url(path))
     end
@@ -945,6 +977,7 @@ defmodule Wallaby.Browser do
     case driver.set_cookie(session, key, value) do
       {:ok, _list} ->
         session
+
       {:error, :invalid_cookie_domain} ->
         raise CookieError
     end
@@ -1045,7 +1078,7 @@ defmodule Wallaby.Browser do
   end
 
   defp validate_html(parent, %{html_validation: :button_type} = query) do
-    buttons = all(parent, Query.css("button", [text: query.selector]))
+    buttons = all(parent, Query.css("button", text: query.selector))
 
     if Enum.count(buttons) == 1 && Enum.any?(buttons) do
       {:error, :button_with_bad_type}
@@ -1053,12 +1086,13 @@ defmodule Wallaby.Browser do
       {:ok, query}
     end
   end
+
   defp validate_html(parent, %{html_validation: :bad_label} = query) do
     label_query = Query.css("label", text: query.selector)
     labels = all(parent, label_query)
 
     if Enum.count(labels) == 1 do
-      if Enum.any?(labels, &(missing_for?(&1))) do
+      if Enum.any?(labels, &missing_for?(&1)) do
         {:error, :label_with_no_for}
       else
         label = List.first(labels)
@@ -1068,6 +1102,7 @@ defmodule Wallaby.Browser do
       {:ok, query}
     end
   end
+
   defp validate_html(_, query), do: {:ok, query}
 
   defp missing_for?(element) do
@@ -1078,10 +1113,12 @@ defmodule Wallaby.Browser do
     case Query.visible?(query) do
       :any ->
         {:ok, elements}
+
       true ->
-        {:ok, Enum.filter(elements, &(Element.visible?(&1)))}
+        {:ok, Enum.filter(elements, &Element.visible?(&1))}
+
       false ->
-        {:ok, Enum.reject(elements, &(Element.visible?(&1)))}
+        {:ok, Enum.reject(elements, &Element.visible?(&1))}
     end
   end
 
@@ -1089,10 +1126,12 @@ defmodule Wallaby.Browser do
     case Query.selected?(query) do
       :any ->
         {:ok, elements}
+
       true ->
-        {:ok, Enum.filter(elements, &(Element.selected?(&1)))}
+        {:ok, Enum.filter(elements, &Element.selected?(&1))}
+
       false ->
-        {:ok, Enum.reject(elements, &(Element.selected?(&1)))}
+        {:ok, Enum.reject(elements, &Element.selected?(&1))}
     end
   end
 
@@ -1108,8 +1147,10 @@ defmodule Wallaby.Browser do
     case {Query.at_number(query), length(elements)} do
       {:all, _} ->
         {:ok, elements}
+
       {n, count} when n >= 0 and n < count ->
         {:ok, [Enum.at(elements, n)]}
+
       {_, _} ->
         {:error, {:at_number, query}}
     end
@@ -1119,7 +1160,7 @@ defmodule Wallaby.Browser do
     text = Query.inner_text(query)
 
     if text do
-      {:ok, Enum.filter(elements, &(matching_text?(&1, text)))}
+      {:ok, Enum.filter(elements, &matching_text?(&1, text))}
     else
       {:ok, elements}
     end
@@ -1129,30 +1170,30 @@ defmodule Wallaby.Browser do
     case driver.text(element) do
       {:ok, element_text} ->
         element_text =~ ~r/#{Regex.escape(text)}/
+
       {:error, _} ->
         false
     end
   end
 
   def execute_query(%{driver: driver} = parent, query) do
-    retry fn ->
+    retry(fn ->
       try do
-        with {:ok, query}  <- Query.validate(query),
+        with {:ok, query} <- Query.validate(query),
              compiled_query <- Query.compile(query),
              {:ok, elements} <- driver.find_elements(parent, compiled_query),
              {:ok, elements} <- validate_visibility(query, elements),
              {:ok, elements} <- validate_text(query, elements),
              {:ok, elements} <- validate_selected(query, elements),
              {:ok, elements} <- validate_count(query, elements),
-             {:ok, elements} <- do_at(query, elements)
-         do
-           {:ok, %Query{query | result: elements}}
+             {:ok, elements} <- do_at(query, elements) do
+          {:ok, %Query{query | result: elements}}
         end
       rescue
         StaleReferenceError ->
           {:error, :stale_reference}
       end
-    end
+    end)
   end
 
   defp max_time_exceeded?(start_time) do

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -4,204 +4,210 @@ defmodule Wallaby.Driver do
   alias Wallaby.{Element, Query, Session}
 
   @type reason :: :not_implemented | :not_supported | any
-  @type url :: String.t
-  @type open_dialog_fn :: ((Session.t) -> any)
-  @type window_dimension :: %{String.t => pos_integer, String.t => pos_integer}
-  @type window_position :: %{String.t => pos_integer, String.t => pos_integer}
+  @type url :: String.t()
+  @type open_dialog_fn :: (Session.t() -> any)
+  @type window_dimension :: %{String.t() => pos_integer, String.t() => pos_integer}
+  @type window_position :: %{String.t() => pos_integer, String.t() => pos_integer}
 
-  @type on_start_session :: {:ok, Session.t} | {:error, reason}
+  @type on_start_session :: {:ok, Session.t()} | {:error, reason}
 
   @doc """
   Invoked to start a browser session.
   """
-  @callback start_session(Keyword.t) :: on_start_session
+  @callback start_session(Keyword.t()) :: on_start_session
 
   @doc """
   Invoked to stop a browser session.
   """
-  @callback end_session(Session.t) :: :ok | {:error, reason}
+  @callback end_session(Session.t()) :: :ok | {:error, reason}
 
   @doc """
   Invoked to accept one alert triggered within `open_dialog_fn` and return the alert message.
   """
-  @callback accept_alert(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
+  @callback accept_alert(Session.t(), open_dialog_fn) :: {:ok, [String.t()]} | {:error, reason}
 
   @doc """
   Invoked to accept one confirm triggered within `open_dialog_fn` and return the confirm message.
   """
-  @callback accept_confirm(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
+  @callback accept_confirm(Session.t(), open_dialog_fn) :: {:ok, [String.t()]} | {:error, reason}
 
   @doc """
   Invoked to accept one prompt triggered within `open_dialog_fn` and return the prompt message.
   """
-  @callback accept_prompt(Session.t, String.t | nil, open_dialog_fn) ::
-    {:ok, [String.t]} | {:error, reason}
+  @callback accept_prompt(Session.t(), String.t() | nil, open_dialog_fn) ::
+              {:ok, [String.t()]} | {:error, reason}
 
   @doc """
   Invoked to close the currently focused window.
   """
-  @callback close_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
+  @callback close_window(Session.t() | Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve cookies for the given session.
   """
-  @callback cookies(Session.t) :: {:ok, [%{String.t => String.t}]} | {:error, reason}
+  @callback cookies(Session.t()) :: {:ok, [%{String.t() => String.t()}]} | {:error, reason}
 
   @doc """
   Invoked to get the current path of the browser's session.
   """
-  @callback current_path(Session.t) :: {:ok, String.t} | {:error, reason}
+  @callback current_path(Session.t()) :: {:ok, String.t()} | {:error, reason}
 
   @doc """
   Invoked to get the current url of the browser's session.
   """
-  @callback current_url(Session.t) :: {:ok, String.t} | {:error, reason}
+  @callback current_url(Session.t()) :: {:ok, String.t()} | {:error, reason}
 
   @doc """
   Invoked to dismiss one confirm triggered within `open_dialog_fn` and return the confirm message.
   """
-  @callback dismiss_confirm(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
+  @callback dismiss_confirm(Session.t(), open_dialog_fn) :: {:ok, [String.t()]} | {:error, reason}
 
   @doc """
   Invoked to dismiss one prompt triggered within `open_dialog_fn` and return the prompt message.
   """
-  @callback dismiss_prompt(Session.t, open_dialog_fn) :: {:ok, [String.t]} | {:error, reason}
+  @callback dismiss_prompt(Session.t(), open_dialog_fn) :: {:ok, [String.t()]} | {:error, reason}
 
   @doc """
   Invoked to change the driver focus to window specified by handle.
   """
-  @callback focus_window(Session.t | Element.t, String.t) :: {:ok, any} | {:error, reason}
+  @callback focus_window(Session.t() | Element.t(), String.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the position of the currently focused window.
   """
-  @callback get_window_position(Session.t | Element.t) :: {:ok, window_position} | {:error, reason}
+  @callback get_window_position(Session.t() | Element.t()) ::
+              {:ok, window_position} | {:error, reason}
 
   @doc """
   Invoked to retrieve the size of the currently focused window.
   """
-  @callback get_window_size(Session.t | Element.t) :: {:ok, window_dimension} | {:error, reason}
+  @callback get_window_size(Session.t() | Element.t()) ::
+              {:ok, window_dimension} | {:error, reason}
 
   @doc """
   Invoked to maximize the currently focused window.
   """
-  @callback maximize_window(Session.t | Element.t) :: {:ok, any} | {:error, reason}
+  @callback maximize_window(Session.t() | Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to change the driver focus to specified frame.
   """
-  @callback focus_frame(Session.t | Element.t, nil | Element.t) :: {:ok, any} |
-    {:error, reason}
+  @callback focus_frame(Session.t() | Element.t(), nil | Element.t()) ::
+              {:ok, any}
+              | {:error, reason}
 
   @doc """
   Invoked to change the driver focus to parent frame.
   """
-  @callback focus_parent_frame(Session.t | Element.t) :: {:ok, any} | {:error, reason}
+  @callback focus_parent_frame(Session.t() | Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to retrieve the html source of the current page.
   """
-  @callback page_source(Session.t) :: {:ok, String.t} | {:error, reason}
+  @callback page_source(Session.t()) :: {:ok, String.t()} | {:error, reason}
 
   @doc """
   Invoked to retrieve the title of the current page.
   """
-  @callback page_title(Session.t) :: {:ok, String.t} | {:error, reason}
+  @callback page_title(Session.t()) :: {:ok, String.t()} | {:error, reason}
 
   @doc """
   Invoked to set a cookie on a session
   """
-  @callback set_cookie(Session.t, String.t, String.t) :: {:ok, any} | {:error, reason}
+  @callback set_cookie(Session.t(), String.t(), String.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to set the size of the currently focused window.
   """
-  @callback set_window_size(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
-    {:error, reason}
+  @callback set_window_size(Session.t() | Element.t(), pos_integer, pos_integer) ::
+              {:ok, any}
+              | {:error, reason}
 
   @doc """
   Invoked to set the position of the currently focused window.
   """
-  @callback set_window_position(Session.t | Element.t, pos_integer, pos_integer) :: {:ok, any} |
-    {:error, reason}
+  @callback set_window_position(Session.t() | Element.t(), pos_integer, pos_integer) ::
+              {:ok, any}
+              | {:error, reason}
 
   @doc """
   Invoked to visit a url.
   """
-  @callback visit(Session.t, url) :: :ok | {:error, reason}
+  @callback visit(Session.t(), url) :: :ok | {:error, reason}
 
   @doc """
   Invoked to return the value of an element's attribute.
   """
-  @callback attribute(Element.t, String.t) :: {:ok, String.t | nil} |
-    {:error, reason}
+  @callback attribute(Element.t(), String.t()) ::
+              {:ok, String.t() | nil}
+              | {:error, reason}
 
   @doc """
   Invoked to clear an element.
   """
-  @callback clear(Element.t) :: {:ok, any} | {:error, reason}
+  @callback clear(Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to click on an element.
   """
-  @callback click(Element.t) :: {:ok, any} | {:error, reason}
+  @callback click(Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to check if an element is currently visible.
   """
-  @callback displayed(Element.t) :: {:ok, boolean} | {:error, reason}
+  @callback displayed(Element.t()) :: {:ok, boolean} | {:error, reason}
 
   @doc """
   Invoked to check if an element is selected (like a checkbox).
   """
-  @callback selected(Element.t) :: {:ok, boolean} | {:error, reason}
+  @callback selected(Element.t()) :: {:ok, boolean} | {:error, reason}
 
   @doc """
   Invoked to set the value of the given element.
   """
-  @callback set_value(Element.t, any) :: {:ok, any} | {:error, reason}
+  @callback set_value(Element.t(), any) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to return the text from the element.
   """
-  @callback text(Element.t) :: {:ok, any} | {:error, reason}
+  @callback text(Element.t()) :: {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to find child elements of the given session/element.
   """
-  @callback find_elements(Session.t | Element.t, Query.compiled) ::
-    {:ok, [Element.t]} | {:error, reason}
+  @callback find_elements(Session.t() | Element.t(), Query.compiled()) ::
+              {:ok, [Element.t()]} | {:error, reason}
 
   @doc """
   Invoked to execute javascript in the browser.
   """
-  @callback execute_script(Session.t | Element, String.t, [any]) ::
-    {:ok, any} | {:error, reason}
+  @callback execute_script(Session.t() | Element, String.t(), [any]) ::
+              {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to execute asynchronous javascript in the browser.
   """
-  @callback execute_script_async(Session.t | Element, String.t, [any]) ::
-    {:ok, any} | {:error, reason}
+  @callback execute_script_async(Session.t() | Element, String.t(), [any]) ::
+              {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to send keys to the browser.
   """
-  @callback send_keys(Session.t | Element.t, String.t | [String.t | atom]) ::
-    {:ok, any} | {:error, reason}
+  @callback send_keys(Session.t() | Element.t(), String.t() | [String.t() | atom]) ::
+              {:ok, any} | {:error, reason}
 
   @doc """
   Invoked to take a screenshot of the session/element.
   """
-  @callback take_screenshot(Session.t | Element.t) :: binary | {:error, reason}
+  @callback take_screenshot(Session.t() | Element.t()) :: binary | {:error, reason}
 
   @doc """
   Invoked to get the handle for the currently focused window.
   """
-  @callback window_handle(Session.t | Element.t) :: {:ok, String.t} | {:error, reason}
+  @callback window_handle(Session.t() | Element.t()) :: {:ok, String.t()} | {:error, reason}
 
   @doc """
   Invoked to get the list of handles for all windows.
   """
-  @callback window_handles(Session.t | Element.t) :: {:ok, [String.t]} | {:error, reason}
+  @callback window_handles(Session.t() | Element.t()) :: {:ok, [String.t()]} | {:error, reason}
 end

--- a/lib/wallaby/driver/external_command.ex
+++ b/lib/wallaby/driver/external_command.ex
@@ -2,9 +2,9 @@ defmodule Wallaby.Driver.ExternalCommand do
   @moduledoc false
 
   @type t :: %__MODULE__{
-    executable: String.t,
-    args: [String.t]
-  }
+          executable: String.t(),
+          args: [String.t()]
+        }
 
   defstruct [:executable, args: []]
 end

--- a/lib/wallaby/driver/log_store.ex
+++ b/lib/wallaby/driver/log_store.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Driver.LogStore do
   def start_link(opts) do
     opts = Keyword.put_new(opts, :name, __MODULE__)
 
-    Agent.start_link(fn -> Map.new end, opts)
+    Agent.start_link(fn -> Map.new() end, opts)
   end
 
   @doc """
@@ -19,12 +19,12 @@ defmodule Wallaby.Driver.LogStore do
   end
 
   def append_logs(session, logs, log_store) when is_binary(session) do
-    Agent.get_and_update log_store, fn(map) ->
-      Map.get_and_update map, session, fn
-        nil      -> unique_logs([], logs)
+    Agent.get_and_update(log_store, fn map ->
+      Map.get_and_update(map, session, fn
+        nil -> unique_logs([], logs)
         old_logs -> unique_logs(old_logs, logs)
-      end
-    end
+      end)
+    end)
   end
 
   def get_logs(session, log_store \\ __MODULE__) when is_binary(session) do
@@ -32,7 +32,7 @@ defmodule Wallaby.Driver.LogStore do
   end
 
   defp unique_logs(old_logs, new_logs) do
-    union = (new_logs -- old_logs)
+    union = new_logs -- old_logs
     {union, old_logs ++ union}
   end
 end

--- a/lib/wallaby/driver/process_workspace.ex
+++ b/lib/wallaby/driver/process_workspace.ex
@@ -6,14 +6,14 @@ defmodule Wallaby.Driver.ProcessWorkspace do
 
   # Creates a temporary workspace for a process that will
   # be cleaned up after the process goes down.
-  @spec create(pid, String.t) :: {:ok, String.t}
+  @spec create(pid, String.t()) :: {:ok, String.t()}
   def create(process_pid, workspace_path \\ generate_workspace_path()) do
     {:ok, _} = ServerSupervisor.start_server(process_pid, workspace_path)
     {:ok, workspace_path}
   end
 
   defp generate_workspace_path do
-    System.tmp_dir!
+    System.tmp_dir!()
     |> Path.join(tmp_dir_prefix())
     |> TemporaryPath.generate()
   end

--- a/lib/wallaby/driver/process_workspace/server.ex
+++ b/lib/wallaby/driver/process_workspace/server.ex
@@ -3,7 +3,7 @@ defmodule Wallaby.Driver.ProcessWorkspace.Server do
 
   use GenServer
 
-  @spec start_link(pid, String.t) :: GenServer.on_start
+  @spec start_link(pid, String.t()) :: GenServer.on_start()
   def start_link(process_pid, workspace_path) do
     GenServer.start_link(__MODULE__, [process_pid, workspace_path])
   end
@@ -18,15 +18,20 @@ defmodule Wallaby.Driver.ProcessWorkspace.Server do
   end
 
   @impl GenServer
-  def handle_info({:DOWN, ref, :process, _, _}, %{ref: ref, workspace_path: workspace_path} = state) do
+  def handle_info(
+        {:DOWN, ref, :process, _, _},
+        %{ref: ref, workspace_path: workspace_path} = state
+      ) do
     File.rm_rf(workspace_path)
     {:stop, :normal, state}
   end
+
   def handle_info(_, state), do: {:noreply, state}
 
   @impl GenServer
   def terminate(:shutdown, %{workspace_path: workspace_path}) do
     File.rm_rf(workspace_path)
   end
+
   def terminate(_, _), do: :ok
 end

--- a/lib/wallaby/driver/process_workspace/server_supervisor.ex
+++ b/lib/wallaby/driver/process_workspace/server_supervisor.ex
@@ -5,12 +5,12 @@ defmodule Wallaby.Driver.ProcessWorkspace.ServerSupervisor do
 
   alias Wallaby.Driver.ProcessWorkspace.Server
 
-  @spec start_link :: Supervisor.on_start
+  @spec start_link :: Supervisor.on_start()
   def start_link do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @spec start_server(pid, String.t) :: Supervisor.on_start_child
+  @spec start_server(pid, String.t()) :: Supervisor.on_start_child()
   def start_server(process_pid, workspace_path) do
     Supervisor.start_child(__MODULE__, [process_pid, workspace_path])
   end

--- a/lib/wallaby/driver/temporary_path.ex
+++ b/lib/wallaby/driver/temporary_path.ex
@@ -1,13 +1,13 @@
 defmodule Wallaby.Driver.TemporaryPath do
   @moduledoc false
 
-  @spec generate(String.t) :: String.t
+  @spec generate(String.t()) :: String.t()
   def generate(base_path \\ System.tmp_dir!()) do
     dirname =
       0x100000000
       |> :rand.uniform()
       |> Integer.to_string(36)
-      |> String.downcase
+      |> String.downcase()
 
     Path.join(base_path, dirname)
   end

--- a/lib/wallaby/element.ex
+++ b/lib/wallaby/element.ex
@@ -30,19 +30,20 @@ defmodule Wallaby.Element do
 
   defstruct [:url, :session_url, :parent, :id, :driver, screenshots: []]
 
-  @type value :: String.t
-               | number()
-               | :selected
-               | :unselected
-  @type attr :: String.t
-  @type keys_to_send :: String.t | list(atom | String.t)
+  @type value ::
+          String.t()
+          | number()
+          | :selected
+          | :unselected
+  @type attr :: String.t()
+  @type keys_to_send :: String.t() | list(atom | String.t())
   @type t :: %__MODULE__{
-    session_url: String.t,
-    url: String.t,
-    id: String.t,
-    screenshots: list,
-    driver: module,
-  }
+          session_url: String.t(),
+          url: String.t(),
+          id: String.t(),
+          screenshots: list,
+          driver: module
+        }
 
   @doc """
   Clears any value set in the element.
@@ -53,8 +54,10 @@ defmodule Wallaby.Element do
     case driver.clear(element) do
       {:ok, _} ->
         element
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
+
       {:error, :invalid_selector} ->
         raise InvalidSelectorError
     end
@@ -63,11 +66,12 @@ defmodule Wallaby.Element do
   @doc """
   Fills in the element with the specified value.
   """
-  @spec fill_in(t, with: String.t | number()) :: t
+  @spec fill_in(t, with: String.t() | number()) :: t
 
   def fill_in(element, with: value) when is_number(value) do
     fill_in(element, with: to_string(value))
   end
+
   def fill_in(element, with: value) when is_binary(value) do
     element
     |> clear
@@ -83,8 +87,10 @@ defmodule Wallaby.Element do
     case driver.click(element) do
       {:ok, _} ->
         element
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
+
       {:error, :obscured} ->
         if retry_count > 4 do
           raise Wallaby.ExpectationNotMetError, """
@@ -113,12 +119,13 @@ defmodule Wallaby.Element do
 
   If the element is not visible, the return value will be `""`.
   """
-  @spec text(t) :: String.t
+  @spec text(t) :: String.t()
 
   def text(%__MODULE__{driver: driver} = element) do
     case driver.text(element) do
       {:ok, text} ->
         text
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
     end
@@ -127,12 +134,13 @@ defmodule Wallaby.Element do
   @doc """
   Gets the value of the element's attribute.
   """
-  @spec attr(t, attr()) :: String.t | nil
+  @spec attr(t, attr()) :: String.t() | nil
 
   def attr(%__MODULE__{driver: driver} = element, name) do
     case driver.attribute(element, name) do
       {:ok, attribute} ->
         attribute
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
     end
@@ -152,6 +160,7 @@ defmodule Wallaby.Element do
     case driver.selected(element) do
       {:ok, value} ->
         value
+
       {:error, _} ->
         false
     end
@@ -166,6 +175,7 @@ defmodule Wallaby.Element do
     case driver.displayed(element) do
       {:ok, value} ->
         value
+
       {:error, _} ->
         false
     end
@@ -180,9 +190,12 @@ defmodule Wallaby.Element do
     case driver.set_value(element, value) do
       {:ok, _} ->
         element
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
-      error -> error
+
+      error ->
+        error
     end
   end
 
@@ -194,27 +207,31 @@ defmodule Wallaby.Element do
   def send_keys(element, text) when is_binary(text) do
     send_keys(element, [text])
   end
+
   def send_keys(%__MODULE__{driver: driver} = element, keys) when is_list(keys) do
     case driver.send_keys(element, keys) do
       {:ok, _} ->
         element
+
       {:error, :stale_reference} ->
         raise StaleReferenceError
-      error -> error
+
+      error ->
+        error
     end
   end
 
   @doc """
   Matches the Element's value with the provided value.
   """
-  @spec value(t) :: String.t
+  @spec value(t) :: String.t()
 
   def value(element) do
     attr(element, "value")
   end
 end
 
-defimpl Inspect, for: Wallaby.Element  do
+defimpl Inspect, for: Wallaby.Element do
   import Inspect.Algebra
 
   def inspect(element, opts) do
@@ -223,8 +240,8 @@ defimpl Inspect, for: Wallaby.Element  do
     concat([
       Inspect.Any.inspect(element, opts),
       "\n\n",
-      IO.ANSI.cyan <> "outerHTML:\n\n" <> IO.ANSI.reset,
-      IO.ANSI.yellow <> outer_html <> IO.ANSI.reset
+      IO.ANSI.cyan() <> "outerHTML:\n\n" <> IO.ANSI.reset(),
+      IO.ANSI.yellow() <> outer_html <> IO.ANSI.reset()
     ])
   end
 end

--- a/lib/wallaby/experimental/chrome/chromedriver.ex
+++ b/lib/wallaby/experimental/chrome/chromedriver.ex
@@ -6,7 +6,7 @@ defmodule Wallaby.Experimental.Chrome.Chromedriver do
   alias Wallaby.Experimental.Chrome
 
   def start_link do
-    GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
   def stop do
@@ -50,18 +50,20 @@ defmodule Wallaby.Experimental.Chrome.Chromedriver do
     Path.absname("priv/run_command.sh", Application.app_dir(:wallaby))
   end
 
-  defp args(chromedriver, port), do: [
+  defp args(chromedriver, port),
+    do: [
       chromedriver,
       "--log-level=OFF",
-      "--port=#{port}",
+      "--port=#{port}"
     ]
 
-  defp port_opts(chromedriver, tcp_port), do: [
-    :binary,
-    :stream,
-    :use_stdio,
-    :stderr_to_stdout,
-    :exit_status,
-    args: args(chromedriver, tcp_port),
-  ]
+  defp port_opts(chromedriver, tcp_port),
+    do: [
+      :binary,
+      :stream,
+      :use_stdio,
+      :stderr_to_stdout,
+      :exit_status,
+      args: args(chromedriver, tcp_port)
+    ]
 end

--- a/lib/wallaby/experimental/chrome/logger.ex
+++ b/lib/wallaby/experimental/chrome/logger.ex
@@ -4,13 +4,13 @@ defmodule Wallaby.Experimental.Chrome.Logger do
   @string_regex ~r/^"(?<string>.+)"$/
 
   def parse_log(%{"level" => "SEVERE", "source" => "javascript", "message" => msg}) do
-    if Wallaby.js_errors? do
+    if Wallaby.js_errors?() do
       raise Wallaby.JSError, msg
     end
   end
 
   def parse_log(%{"level" => "INFO", "source" => "console-api", "message" => msg}) do
-    if Wallaby.js_logger do
+    if Wallaby.js_logger() do
       case Regex.named_captures(@log_regex, msg) do
         %{"message" => message} -> print_message(message)
       end
@@ -20,16 +20,18 @@ defmodule Wallaby.Experimental.Chrome.Logger do
   def parse_log(_), do: nil
 
   defp print_message(message) do
-    message = case Regex.named_captures(@string_regex, message) do
-      %{"string" => string} -> format_string(string)
-      nil -> message
-    end
+    message =
+      case Regex.named_captures(@string_regex, message) do
+        %{"string" => string} -> format_string(string)
+        nil -> message
+      end
 
-    IO.puts(Wallaby.js_logger, message)
+    IO.puts(Wallaby.js_logger(), message)
   end
 
   defp format_string(message) do
     unescaped = String.replace(message, ~r/\\(.)/, "\\1")
+
     case Jason.decode(unescaped) do
       {:ok, data} -> "\n#{Jason.encode!(data, pretty: true)}"
       {:error, _} -> unescaped

--- a/lib/wallaby/experimental/selenium/webdriver_client.ex
+++ b/lib/wallaby/experimental/selenium/webdriver_client.ex
@@ -29,7 +29,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   """
   @spec delete_session(Session.t() | Element.t()) :: {:ok, map}
   def delete_session(session) do
-      request(:delete, session.session_url, %{})
+    request(:delete, session.session_url, %{})
   rescue
     _ -> {:ok, %{}}
   end
@@ -430,11 +430,15 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClient do
   Executes asynchronous javascript, taking as arguments the script to execute,
   and optionally a list of arguments available in the script via `arguments`
   """
-  @spec execute_script_async(Session.t | Element.t, String.t, Keyword.t) :: {:ok, any}
+  @spec execute_script_async(Session.t() | Element.t(), String.t(), Keyword.t()) :: {:ok, any}
   def execute_script_async(session, script, arguments \\ []) do
-    with {:ok, resp} <- request(:post, "#{session.session_url}/execute_async", %{script: script, args: arguments}),
-          {:ok, value} <- Map.fetch(resp, "value"),
-      do: {:ok, value}
+    with {:ok, resp} <-
+           request(:post, "#{session.session_url}/execute_async", %{
+             script: script,
+             args: arguments
+           }),
+         {:ok, value} <- Map.fetch(resp, "value"),
+         do: {:ok, value}
   end
 
   @doc """

--- a/lib/wallaby/helpers/key_codes.ex
+++ b/lib/wallaby/helpers/key_codes.ex
@@ -7,12 +7,12 @@ defmodule Wallaby.Helpers.KeyCodes do
   @doc """
   Encode a list of key codes to a usable json representation.
   """
-  @spec json(list(atom)) :: String.t
+  @spec json(list(atom)) :: String.t()
 
   def json(keys) when is_list(keys) do
     unicode =
       keys
-      |> Enum.reduce([], fn (x, acc) -> acc ++ split_strings(x) end)
+      |> Enum.reduce([], fn x, acc -> acc ++ split_strings(x) end)
       |> Enum.map(&"\"#{code(&1)}\"")
       |> Enum.join(",")
 
@@ -22,53 +22,53 @@ defmodule Wallaby.Helpers.KeyCodes do
   defp split_strings(x) when is_binary(x), do: String.graphemes(x)
   defp split_strings(x), do: [x]
 
-  defp code(:null),      do: "\\uE000"
-  defp code(:cancel),    do: "\\uE001"
-  defp code(:help),      do: "\\uE002"
+  defp code(:null), do: "\\uE000"
+  defp code(:cancel), do: "\\uE001"
+  defp code(:help), do: "\\uE002"
   defp code(:backspace), do: "\\uE003"
-  defp code(:tab),       do: "\\uE004"
-  defp code(:clear),     do: "\\uE005"
-  defp code(:return),    do: "\\uE006"
-  defp code(:enter),     do: "\\uE007"
-  defp code(:shift),     do: "\\uE008"
-  defp code(:control),   do: "\\uE009"
-  defp code(:alt),       do: "\\uE00A"
-  defp code(:pause),     do: "\\uE00B"
-  defp code(:escape),    do: "\\uE00C"
+  defp code(:tab), do: "\\uE004"
+  defp code(:clear), do: "\\uE005"
+  defp code(:return), do: "\\uE006"
+  defp code(:enter), do: "\\uE007"
+  defp code(:shift), do: "\\uE008"
+  defp code(:control), do: "\\uE009"
+  defp code(:alt), do: "\\uE00A"
+  defp code(:pause), do: "\\uE00B"
+  defp code(:escape), do: "\\uE00C"
 
-  defp code(:space),       do: "\\uE00D"
-  defp code(:pageup),      do: "\\uE00E"
-  defp code(:pagedown),    do: "\\uE00F"
-  defp code(:end),         do: "\\uE010"
-  defp code(:home),        do: "\\uE011"
-  defp code(:left_arrow),  do: "\\uE012"
-  defp code(:up_arrow),    do: "\\uE013"
+  defp code(:space), do: "\\uE00D"
+  defp code(:pageup), do: "\\uE00E"
+  defp code(:pagedown), do: "\\uE00F"
+  defp code(:end), do: "\\uE010"
+  defp code(:home), do: "\\uE011"
+  defp code(:left_arrow), do: "\\uE012"
+  defp code(:up_arrow), do: "\\uE013"
   defp code(:right_arrow), do: "\\uE014"
-  defp code(:down_arrow),  do: "\\uE015"
-  defp code(:insert),      do: "\\uE016"
-  defp code(:delete),      do: "\\uE017"
-  defp code(:semicolon),   do: "\\uE018"
-  defp code(:equals),      do: "\\uE019"
+  defp code(:down_arrow), do: "\\uE015"
+  defp code(:insert), do: "\\uE016"
+  defp code(:delete), do: "\\uE017"
+  defp code(:semicolon), do: "\\uE018"
+  defp code(:equals), do: "\\uE019"
 
-  defp code(:num0),      do: "\\uE01A"
-  defp code(:num1),      do: "\\uE01B"
-  defp code(:num2),      do: "\\uE01C"
-  defp code(:num3),      do: "\\uE01D"
-  defp code(:num4),      do: "\\uE01E"
-  defp code(:num5),      do: "\\uE01F"
-  defp code(:num6),      do: "\\uE020"
-  defp code(:num7),      do: "\\uE021"
-  defp code(:num8),      do: "\\uE022"
-  defp code(:num9),      do: "\\uE023"
+  defp code(:num0), do: "\\uE01A"
+  defp code(:num1), do: "\\uE01B"
+  defp code(:num2), do: "\\uE01C"
+  defp code(:num3), do: "\\uE01D"
+  defp code(:num4), do: "\\uE01E"
+  defp code(:num5), do: "\\uE01F"
+  defp code(:num6), do: "\\uE020"
+  defp code(:num7), do: "\\uE021"
+  defp code(:num8), do: "\\uE022"
+  defp code(:num9), do: "\\uE023"
 
-  defp code(:multiply),  do: "\\uE024"
-  defp code(:add),       do: "\\uE025"
+  defp code(:multiply), do: "\\uE024"
+  defp code(:add), do: "\\uE025"
   defp code(:seperator), do: "\\uE026"
-  defp code(:subtract),  do: "\\uE027"
-  defp code(:decimal),   do: "\\uE028"
-  defp code(:divide),    do: "\\uE029"
+  defp code(:subtract), do: "\\uE027"
+  defp code(:decimal), do: "\\uE028"
+  defp code(:divide), do: "\\uE029"
 
-  defp code(:command),   do: "\\uE03D"
+  defp code(:command), do: "\\uE03D"
 
   defp code(char), do: char
 end

--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -2,40 +2,47 @@ defmodule Wallaby.HTTPClient do
   @moduledoc false
 
   @type method :: :post | :get | :delete
-  @type url :: String.t
-  @type params :: map | String.t
+  @type url :: String.t()
+  @type params :: map | String.t()
   @type request_opts :: {:encode_json, boolean}
 
   @status_obscured 13
-  @max_jitter 50 # The maximum time we'll sleep is for 50ms
+  # The maximum time we'll sleep is for 50ms
+  @max_jitter 50
 
   @doc """
   Sends a request to the webdriver API and parses the
   response.
   """
-  @spec request(method, url, params, [request_opts]) :: {:ok, any}
-                                                      | {:error, :invalid_selector}
-                                                      | {:error, :stale_reference}
-                                                      | {:error, :httpoison}
+  @spec request(method, url, params, [request_opts]) ::
+          {:ok, any}
+          | {:error, :invalid_selector}
+          | {:error, :stale_reference}
+          | {:error, :httpoison}
 
   def request(method, url, params \\ %{}, opts \\ [])
+
   def request(method, url, params, _opts) when map_size(params) == 0 do
     make_request(method, url, "")
   end
+
   def request(method, url, params, [{:encode_json, false} | _]) do
     make_request(method, url, params)
   end
+
   def request(method, url, params, _opts) do
     make_request(method, url, Jason.encode!(params))
   end
 
   defp make_request(method, url, body), do: make_request(method, url, body, 0, [])
+
   defp make_request(_, _, _, 5, retry_reasons) do
     ["Wallaby had an internal issue with HTTPoison:" | retry_reasons]
     |> Enum.uniq()
     |> Enum.join("\n")
     |> raise
   end
+
   defp make_request(method, url, body, retry_count, retry_reasons) do
     method
     |> HTTPoison.request(url, body, headers(), request_opts())
@@ -62,7 +69,7 @@ defmodule Wallaby.HTTPClient do
         with {:ok, decoded} <- Jason.decode(body),
              {:ok, response} <- check_status(decoded),
              {:ok, validated} <- check_for_response_errors(response),
-          do: {:ok, validated}
+             do: {:ok, validated}
     end
   end
 
@@ -72,7 +79,8 @@ defmodule Wallaby.HTTPClient do
         message = get_in(response, ["value", "message"])
 
         {:error, message}
-      _  ->
+
+      _ ->
         {:ok, response}
     end
   end
@@ -82,39 +90,51 @@ defmodule Wallaby.HTTPClient do
     case Map.get(response, "value") do
       %{"class" => "org.openqa.selenium.StaleElementReferenceException"} ->
         {:error, :stale_reference}
+
       %{"message" => "Stale element reference" <> _} ->
         {:error, :stale_reference}
+
       %{"message" => "stale element reference" <> _} ->
         {:error, :stale_reference}
-      %{"message" => "An element command failed because the referenced element is no longer available" <> _} ->
+
+      %{
+        "message" =>
+          "An element command failed because the referenced element is no longer available" <> _
+      } ->
         {:error, :stale_reference}
+
       %{"message" => "invalid selector" <> _} ->
         {:error, :invalid_selector}
+
       %{"class" => "org.openqa.selenium.InvalidSelectorException"} ->
         {:error, :invalid_selector}
+
       %{"class" => "org.openqa.selenium.InvalidElementStateException"} ->
         {:error, :invalid_selector}
+
       %{"message" => "unexpected alert" <> _} ->
         {:error, :unexpected_alert}
+
       %{"error" => _, "message" => message} ->
         raise message
+
       _ ->
         {:ok, response}
     end
   end
 
   defp request_opts do
-    Application.get_env(:wallaby, :hackney_options, [hackney: [pool: :wallaby_pool]])
+    Application.get_env(:wallaby, :hackney_options, hackney: [pool: :wallaby_pool])
   end
 
   defp headers do
-    [{"Accept", "application/json"},
-      {"Content-Type", "application/json"}]
+    [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
   end
 
   def to_params({:xpath, xpath}) do
     %{using: "xpath", value: xpath}
   end
+
   def to_params({:css, css}) do
     %{using: "css selector", value: css}
   end

--- a/lib/wallaby/metadata.ex
+++ b/lib/wallaby/metadata.ex
@@ -9,9 +9,11 @@ defmodule Wallaby.Metadata do
   @regex ~r{#{@prefix} \((.*?)\)}
 
   def append(user_agent, nil), do: user_agent
+
   def append(user_agent, metadata) when is_map(metadata) or is_list(metadata) do
     append(user_agent, format(metadata))
   end
+
   def append(user_agent, metadata) when is_binary(metadata) do
     "#{user_agent}/#{metadata}"
   end
@@ -22,8 +24,9 @@ defmodule Wallaby.Metadata do
   def format(metadata) do
     encoded =
       {:v1, metadata}
-      |> :erlang.term_to_binary
-      |> Base.url_encode64
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64()
+
     "#{@prefix} (#{encoded})"
   end
 
@@ -31,21 +34,21 @@ defmodule Wallaby.Metadata do
     ua =
       str
       |> String.split("/")
-      |> List.last
+      |> List.last()
 
     case Regex.run(@regex, ua) do
       [_, metadata] -> parse(metadata)
-      _             -> %{}
+      _ -> %{}
     end
   end
 
   def parse(encoded_metadata) do
     encoded_metadata
-    |> Base.url_decode64!
-    |> :erlang.binary_to_term
+    |> Base.url_decode64!()
+    |> :erlang.binary_to_term()
     |> case do
-        {:v1, metadata} -> metadata
-        _               -> raise Wallaby.BadMetadataError, message: "#{encoded_metadata} is not valid"
-      end
+      {:v1, metadata} -> metadata
+      _ -> raise Wallaby.BadMetadataError, message: "#{encoded_metadata} is not valid"
+    end
   end
 end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -48,17 +48,21 @@ defmodule Wallaby.Phantom do
   def validate do
     cond do
       configured_phantom_js()
-      |> Path.expand
-      |> System.find_executable ->
+      |> Path.expand()
+      |> System.find_executable() ->
         :ok
+
       System.find_executable("phantomjs") ->
         :ok
+
       true ->
-        exception = DependencyError.exception """
-        Wallaby can't find phantomjs. Make sure you have phantomjs installed
-        and included in your path, or that your `config :wallaby, :phantomjs`
-        setting points to a valid phantomjs executable.
-        """
+        exception =
+          DependencyError.exception("""
+          Wallaby can't find phantomjs. Make sure you have phantomjs installed
+          and included in your path, or that your `config :wallaby, :phantomjs`
+          setting points to a valid phantomjs executable.
+          """)
+
         {:error, exception}
     end
   end
@@ -66,7 +70,7 @@ defmodule Wallaby.Phantom do
   def init(:ok) do
     children = [
       :poolboy.child_spec(@pool_name, poolboy_config(), []),
-      worker(Wallaby.Driver.LogStore, [[]]),
+      worker(Wallaby.Driver.LogStore, [[]])
     ]
 
     supervise(children, strategy: :one_for_one)
@@ -90,7 +94,7 @@ defmodule Wallaby.Phantom do
       cssSelectorsEnabled: true,
       browserName: "phantomjs",
       nativeEvents: false,
-      platform: "ANY",
+      platform: "ANY"
     }
   end
 
@@ -102,8 +106,7 @@ defmodule Wallaby.Phantom do
 
   @doc false
   def end_session(%Wallaby.Session{server: server} = session) do
-    Driver.execute_script(session, "localStorage.clear()", [],
-                          check_logs: false)
+    Driver.execute_script(session, "localStorage.clear()", [], check_logs: false)
     Driver.delete(session)
     :poolboy.checkin(Wallaby.ServerPool, server)
   end
@@ -179,14 +182,16 @@ defmodule Wallaby.Phantom do
 
   @doc false
   def user_agent_capability(nil), do: %{}
+
   def user_agent_capability(ua) do
     %{"phantomjs.page.settings.userAgent" => ua}
   end
 
   @doc false
   def custom_headers_capability(nil), do: %{}
+
   def custom_headers_capability(ch) do
-    Enum.reduce(ch, %{}, fn ({k, v}, acc) ->
+    Enum.reduce(ch, %{}, fn {k, v}, acc ->
       Map.merge(acc, %{"phantomjs.page.customHeaders.#{k}" => v})
     end)
   end
@@ -197,10 +202,12 @@ defmodule Wallaby.Phantom do
   end
 
   defp poolboy_config do
-    [name: {:local, @pool_name},
-     worker_module: Wallaby.Phantom.Server,
-     size: pool_size(),
-     max_overflow: 0]
+    [
+      name: {:local, @pool_name},
+      worker_module: Wallaby.Phantom.Server,
+      size: pool_size(),
+      max_overflow: 0
+    ]
   end
 
   defp default_pool_size do

--- a/lib/wallaby/phantom/logger.ex
+++ b/lib/wallaby/phantom/logger.ex
@@ -3,15 +3,15 @@ defmodule Wallaby.Phantom.Logger do
   @line_number_regex ~r/\s\((undefined)?:(undefined)?\)$/
 
   def parse_log(%{"level" => "WARNING", "message" => msg}) do
-    if Wallaby.js_errors? do
+    if Wallaby.js_errors?() do
       raise Wallaby.JSError, msg
     end
   end
 
   def parse_log(%{"level" => "INFO", "message" => msg}) do
-    if Wallaby.js_logger do
+    if Wallaby.js_logger() do
       msg = Regex.replace(@line_number_regex, msg, "")
-      IO.puts(Wallaby.js_logger, msg)
+      IO.puts(Wallaby.js_logger(), msg)
     end
   end
 

--- a/lib/wallaby/phantom/server/server_state.ex
+++ b/lib/wallaby/phantom/server/server_state.ex
@@ -9,14 +9,14 @@ defmodule Wallaby.Phantom.Server.ServerState do
   @type os_pid :: non_neg_integer
 
   @type t :: %__MODULE__{
-    workspace_path: String.t,
-    port_number: port_number,
-    phantom_path: String.t,
-    phantom_args: [String.t],
-    wrapper_script_port: port | nil,
-    wrapper_script_os_pid: os_pid | nil,
-    phantom_os_pid: os_pid | nil,
-  }
+          workspace_path: String.t(),
+          port_number: port_number,
+          phantom_path: String.t(),
+          phantom_args: [String.t()],
+          wrapper_script_port: port | nil,
+          wrapper_script_os_pid: os_pid | nil,
+          phantom_os_pid: os_pid | nil
+        }
 
   defstruct [
     :workspace_path,
@@ -25,46 +25,47 @@ defmodule Wallaby.Phantom.Server.ServerState do
     :phantom_args,
     :wrapper_script_port,
     :wrapper_script_os_pid,
-    :phantom_os_pid]
+    :phantom_os_pid
+  ]
 
-  @type workspace_path :: String.t
+  @type workspace_path :: String.t()
 
   @type new_opt ::
-    {:port_number, port_number} |
-    {:phantom_path, String.t} |
-    {:phantom_args, [String.t] | String.t}
+          {:port_number, port_number}
+          | {:phantom_path, String.t()}
+          | {:phantom_args, [String.t()] | String.t()}
 
   @spec new(workspace_path, [new_opt]) :: t
   def new(workspace_path, params \\ []) do
     %__MODULE__{
       workspace_path: workspace_path,
-      port_number: Keyword.get_lazy(params, :port_number,
-                                    &Utils.find_available_port/0),
-      phantom_path: Keyword.get_lazy(params, :phantom_path,
-                                    &Wallaby.phantomjs_path/0),
-      phantom_args: params
-                    |> Keyword.get_lazy(:phantom_args, &phantom_args_from_env/0)
-                    |> normalize_phantomjs_args,
+      port_number: Keyword.get_lazy(params, :port_number, &Utils.find_available_port/0),
+      phantom_path: Keyword.get_lazy(params, :phantom_path, &Wallaby.phantomjs_path/0),
+      phantom_args:
+        params
+        |> Keyword.get_lazy(:phantom_args, &phantom_args_from_env/0)
+        |> normalize_phantomjs_args
     }
   end
 
-  @spec base_url(t) :: String.t
+  @spec base_url(t) :: String.t()
   def base_url(%__MODULE__{port_number: port_number}) do
     "http://localhost:#{port_number}/"
   end
 
-  @spec external_command(t) :: ExternalCommand.t
+  @spec external_command(t) :: ExternalCommand.t()
   def external_command(%__MODULE__{} = state) do
     %ExternalCommand{
       executable: state.phantom_path,
-      args: [
-        "--webdriver=#{state.port_number}",
-        "--local-storage-path=#{local_storage_path(state)}",
-      ] ++ state.phantom_args
+      args:
+        [
+          "--webdriver=#{state.port_number}",
+          "--local-storage-path=#{local_storage_path(state)}"
+        ] ++ state.phantom_args
     }
   end
 
-  @spec local_storage_path(t) :: String.t
+  @spec local_storage_path(t) :: String.t()
   def local_storage_path(%__MODULE__{workspace_path: workspace_path}) do
     Path.join(workspace_path, "local_storage")
   end
@@ -74,14 +75,15 @@ defmodule Wallaby.Phantom.Server.ServerState do
     workspace_path |> Path.join("wrapper") |> to_charlist
   end
 
-  @spec phantom_args_from_env :: [String.t] | String.t
+  @spec phantom_args_from_env :: [String.t()] | String.t()
   defp phantom_args_from_env do
     Application.get_env(:wallaby, :phantomjs_args, "")
   end
 
-  @spec normalize_phantomjs_args(String.t | [String.t]) :: [String.t]
+  @spec normalize_phantomjs_args(String.t() | [String.t()]) :: [String.t()]
   defp normalize_phantomjs_args(args) when is_binary(args) do
     String.split(args)
   end
+
   defp normalize_phantomjs_args(args) when is_list(args), do: args
 end

--- a/lib/wallaby/phantom/server/start_task.ex
+++ b/lib/wallaby/phantom/server/start_task.ex
@@ -15,59 +15,63 @@ defmodule Wallaby.Phantom.Server.StartTask do
   @type error_reason :: {:crashed, exit_code}
 
   @external_resource "priv/run_phantom.sh"
-  @run_phantom_script_contents File.read! "priv/run_phantom.sh"
+  @run_phantom_script_contents File.read!("priv/run_phantom.sh")
 
   def async(server_state) do
     Task.async(__MODULE__, :run, [self(), server_state])
   end
 
   @doc false
-  @spec run(pid, ServerState.t) ::
-    {:ok, ServerState.t} | {:error, error_reason}
+  @spec run(pid, ServerState.t()) ::
+          {:ok, ServerState.t()} | {:error, error_reason}
   def run(server_pid, server_state) do
     case server_state |> setup_workspace() |> start_phantom() |> loop() do
       {:ok, server_state} ->
         # Transfers control of port over to the calling process.
         Port.connect(server_state.wrapper_script_port, server_pid)
         {:ok, server_state}
+
       {:error, reason} ->
         {:error, reason}
     end
   end
 
   @doc false
-  @spec loop(ServerState.t) ::
-    {:ok, ServerState.t} | {:error, error_reason}
+  @spec loop(ServerState.t()) ::
+          {:ok, ServerState.t()} | {:error, error_reason}
   def loop(%ServerState{wrapper_script_port: port} = state) do
     receive do
       {^port, {:data, output}} ->
         case analyze_output(output) do
           :phantom_up ->
             {:ok, state}
+
           {:os_pid, os_pid} ->
             loop(%{state | phantom_os_pid: os_pid})
+
           _ ->
             loop(state)
         end
+
       {^port, {:exit_status, status}} ->
         {:error, {:crashed, status}}
     end
   end
 
-  @spec setup_workspace(ServerState.t) :: ServerState.t
+  @spec setup_workspace(ServerState.t()) :: ServerState.t()
   defp setup_workspace(%ServerState{} = state) do
     state
     |> create_local_storage_dir()
     |> write_wrapper_script()
   end
 
-  @spec create_local_storage_dir(ServerState.t) :: ServerState.t
+  @spec create_local_storage_dir(ServerState.t()) :: ServerState.t()
   defp create_local_storage_dir(%ServerState{} = state) do
-    state |> ServerState.local_storage_path |> File.mkdir_p!
+    state |> ServerState.local_storage_path() |> File.mkdir_p!()
     state
   end
 
-  @spec write_wrapper_script(ServerState.t) :: ServerState.t
+  @spec write_wrapper_script(ServerState.t()) :: ServerState.t()
   defp write_wrapper_script(%ServerState{} = state) do
     path = ServerState.wrapper_script_path(state)
 
@@ -77,42 +81,49 @@ defmodule Wallaby.Phantom.Server.StartTask do
     state
   end
 
-  @spec start_phantom(ServerState.t) :: ServerState.t
+  @spec start_phantom(ServerState.t()) :: ServerState.t()
   defp start_phantom(%ServerState{} = state) do
     wrapper_script_port =
       state
       |> ServerState.external_command()
       |> open_port_with_wrapper_script(state)
 
-    %ServerState{state |
-      wrapper_script_port: wrapper_script_port,
-      wrapper_script_os_pid: os_pid_from_port(wrapper_script_port)
+    %ServerState{
+      state
+      | wrapper_script_port: wrapper_script_port,
+        wrapper_script_os_pid: os_pid_from_port(wrapper_script_port)
     }
   end
 
-  @spec analyze_output(String.t) :: :phantom_up | {:os_pid, os_pid} | :unknown
+  @spec analyze_output(String.t()) :: :phantom_up | {:os_pid, os_pid} | :unknown
   defp analyze_output(output) do
     cond do
       output =~ "running on port" ->
         :phantom_up
+
       result = Regex.run(~r{PID: (\d+)}, output) ->
         [_, os_pid] = result
         {:os_pid, String.to_integer(os_pid)}
+
       true ->
         :unknown
     end
   end
 
-  @spec open_port_with_wrapper_script(ExternalCommand.t, ServerState.t) :: port
-  defp open_port_with_wrapper_script(%ExternalCommand{executable: executable, args: args}, %ServerState{} = state) do
-    Port.open({:spawn_executable, ServerState.wrapper_script_path(state)},
-      [:binary, :stream, :use_stdio, :exit_status, :stderr_to_stdout,
-        args: [executable] ++ args])
+  @spec open_port_with_wrapper_script(ExternalCommand.t(), ServerState.t()) :: port
+  defp open_port_with_wrapper_script(
+         %ExternalCommand{executable: executable, args: args},
+         %ServerState{} = state
+       ) do
+    Port.open(
+      {:spawn_executable, ServerState.wrapper_script_path(state)},
+      [:binary, :stream, :use_stdio, :exit_status, :stderr_to_stdout, args: [executable] ++ args]
+    )
   end
 
   @spec os_pid_from_port(port) :: non_neg_integer
   defp os_pid_from_port(port) do
-    %{os_pid: os_pid} = port |> Port.info |> Enum.into(%{})
+    %{os_pid: os_pid} = port |> Port.info() |> Enum.into(%{})
     os_pid
   end
 end

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -87,42 +87,45 @@ defmodule Wallaby.Query do
             conditions: [],
             result: []
 
-  @type method :: :css
-                | :xpath
-                | :link
-                | :button
-                | :fillable_field
-                | :checkbox
-                | :radio_button
-                | :option
-                | :select
-                | :file_field
-  @type attribute_key_value_pair :: {String.t, String.t}
-  @type selector :: String.t
-                  | :attribute_key_value_pair
-  @type html_validation :: :bad_label
-                         | :button_type
-                         | nil
+  @type method ::
+          :css
+          | :xpath
+          | :link
+          | :button
+          | :fillable_field
+          | :checkbox
+          | :radio_button
+          | :option
+          | :select
+          | :file_field
+  @type attribute_key_value_pair :: {String.t(), String.t()}
+  @type selector ::
+          String.t()
+          | :attribute_key_value_pair
+  @type html_validation ::
+          :bad_label
+          | :button_type
+          | nil
   @type conditions :: [
-    count: non_neg_integer,
-    text: String.t,
-    visible: boolean() | :any,
-    selected: boolean() | :any,
-    minimum: non_neg_integer,
-    at: pos_integer
-  ]
-  @type result :: list(Element.t)
+          count: non_neg_integer,
+          text: String.t(),
+          visible: boolean() | :any,
+          selected: boolean() | :any,
+          minimum: non_neg_integer,
+          at: pos_integer
+        ]
+  @type result :: list(Element.t())
   @type opts :: nonempty_list()
 
   @type t :: %__MODULE__{
-    method: method(),
-    selector: selector(),
-    html_validation: html_validation(),
-    conditions: conditions(),
-    result: result(),
-  }
+          method: method(),
+          selector: selector(),
+          html_validation: html_validation(),
+          conditions: conditions(),
+          result: result()
+        }
 
-  @type compiled :: {:xpath | :css, String.t}
+  @type compiled :: {:xpath | :css, String.t()}
 
   @doc """
   Literally queries for the css selector you provide.
@@ -132,7 +135,7 @@ defmodule Wallaby.Query do
     %Query{
       method: :css,
       selector: selector,
-      conditions: build_conditions(opts),
+      conditions: build_conditions(opts)
     }
   end
 
@@ -218,7 +221,7 @@ defmodule Wallaby.Query do
       method: :fillable_field,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -232,7 +235,7 @@ defmodule Wallaby.Query do
       method: :fillable_field,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -246,7 +249,7 @@ defmodule Wallaby.Query do
       method: :radio_button,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -260,7 +263,7 @@ defmodule Wallaby.Query do
       method: :checkbox,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -273,7 +276,7 @@ defmodule Wallaby.Query do
       method: :select,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -285,7 +288,7 @@ defmodule Wallaby.Query do
       method: :option,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -299,7 +302,7 @@ defmodule Wallaby.Query do
       method: :button,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :button_type,
+      html_validation: :button_type
     }
   end
 
@@ -312,7 +315,7 @@ defmodule Wallaby.Query do
       method: :link,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -325,7 +328,7 @@ defmodule Wallaby.Query do
       method: :file_field,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label,
+      html_validation: :bad_label
     }
   end
 
@@ -395,8 +398,10 @@ defmodule Wallaby.Query do
     cond do
       query.conditions[:minimum] > query.conditions[:maximum] ->
         {:error, :min_max}
-      (Query.visible?(query) != true) && Query.inner_text(query) ->
+
+      Query.visible?(query) != true && Query.inner_text(query) ->
         {:error, :cannot_set_text_with_invisible_elements}
+
       true ->
         {:ok, query}
     end
@@ -415,14 +420,25 @@ defmodule Wallaby.Query do
   def compile(%{method: :xpath, selector: selector}), do: {:xpath, selector}
   def compile(%{method: :link, selector: selector}), do: {:xpath, XPath.link(selector)}
   def compile(%{method: :button, selector: selector}), do: {:xpath, XPath.button(selector)}
-  def compile(%{method: :fillable_field, selector: selector}), do: {:xpath, XPath.fillable_field(selector)}
+
+  def compile(%{method: :fillable_field, selector: selector}),
+    do: {:xpath, XPath.fillable_field(selector)}
+
   def compile(%{method: :checkbox, selector: selector}), do: {:xpath, XPath.checkbox(selector)}
-  def compile(%{method: :radio_button, selector: selector}), do: {:xpath, XPath.radio_button(selector)}
+
+  def compile(%{method: :radio_button, selector: selector}),
+    do: {:xpath, XPath.radio_button(selector)}
+
   def compile(%{method: :option, selector: selector}), do: {:xpath, XPath.option(selector)}
   def compile(%{method: :select, selector: selector}), do: {:xpath, XPath.select(selector)}
-  def compile(%{method: :file_field, selector: selector}), do: {:xpath, XPath.file_field(selector)}
+
+  def compile(%{method: :file_field, selector: selector}),
+    do: {:xpath, XPath.file_field(selector)}
+
   def compile(%{method: :text, selector: selector}), do: {:xpath, XPath.text(selector)}
-  def compile(%{method: :attribute, selector: {name, value}}), do: {:xpath, XPath.attribute(name, value)}
+
+  def compile(%{method: :attribute, selector: {name, value}}),
+    do: {:xpath, XPath.attribute(name, value)}
 
   def visible?(%Query{conditions: conditions}) do
     Keyword.get(conditions, :visible)
@@ -454,7 +470,7 @@ defmodule Wallaby.Query do
   end
 
   def specific_element_requested(query) do
-      count(query) == 1 || at_number(query) != :all
+    count(query) == 1 || at_number(query) != :all
   end
 
   def matches_count?(%{conditions: conditions}, count) do
@@ -467,7 +483,7 @@ defmodule Wallaby.Query do
 
       true ->
         !(conditions[:minimum] && conditions[:minimum] > count) &&
-        !(conditions[:maximum] && conditions[:maximum] < count)
+          !(conditions[:maximum] && conditions[:maximum] < count)
     end
   end
 

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -6,14 +6,16 @@ defmodule Wallaby.Query.ErrorMessage do
   @doc """
   Compose an error message based on the error method and query information
   """
-  @spec message(Query.t, any()) :: String.t
+  @spec message(Query.t(), any()) :: String.t()
 
   def message(%Query{} = query, :not_found) do
     "Expected to find #{found_error_message(query)}"
   end
+
   def message(%Query{} = query, :found) do
     "Expected not to find #{found_error_message(query)}"
   end
+
   def message(%{method: method, selector: selector}, :label_with_no_for) do
     """
     The text '#{selector}' matched a label but the label has no 'for'
@@ -23,6 +25,7 @@ defmodule Wallaby.Query.ErrorMessage do
     appropriate label.
     """
   end
+
   def message(%{method: method, selector: selector}, {:label_does_not_find_field, for_text}) do
     """
     The text '#{selector}' matched a label but the label's 'for' attribute
@@ -31,6 +34,7 @@ defmodule Wallaby.Query.ErrorMessage do
     Make sure that id on your #{method(method)} is `id="#{for_text}"`.
     """
   end
+
   def message(%{selector: selector}, :button_with_bad_type) do
     """
     The text '#{selector}' matched a button but the button has an invalid 'type' attribute.
@@ -38,6 +42,7 @@ defmodule Wallaby.Query.ErrorMessage do
     You can fix this by including `type="[submit|reset|button|image]"` on the appropriate button.
     """
   end
+
   def message(_, :cannot_set_text_with_invisible_elements) do
     """
     Cannot set the `text` filter when `visible` is set to `false`.
@@ -47,22 +52,28 @@ defmodule Wallaby.Query.ErrorMessage do
     can't apply both filters correctly.
     """
   end
+
   def message(_, {:at_number, query}) do
-#   The query is invalid. the 'at' number requested is not within the results list (1-#{size}).
+    #   The query is invalid. the 'at' number requested is not within the results list (1-#{size}).
     """
-    The element at index #{Query.at_number(query)} is not available because #{result_count(query.result)} #{method(query)} #{result_expectation(query.result)}
+    The element at index #{Query.at_number(query)} is not available because #{
+      result_count(query.result)
+    } #{method(query)} #{result_expectation(query.result)}
     """
   end
+
   def message(_, :min_max) do
     """
     The query is invalid. Cannot set the minimum greater than the maximum.
     """
   end
+
   def message(%{method: method, selector: selector}, :invalid_selector) do
     """
     The #{method} '#{selector}' is not a valid query.
     """
   end
+
   def message(_, :unexpected_alert) do
     """
     There was an unexpected alert.
@@ -78,18 +89,23 @@ defmodule Wallaby.Query.ErrorMessage do
 
   defp found_error_message(query) do
     """
-    #{expected_count(query)}, #{visibility_and_selection(query)} #{method(query)} #{selector(query)} but #{result_count(query.result)}, #{visibility_and_selection(query)} #{short_method(query.method, Enum.count(query.result))} #{result_expectation(query.result)}.
+    #{expected_count(query)}, #{visibility_and_selection(query)} #{method(query)} #{
+      selector(query)
+    } but #{result_count(query.result)}, #{visibility_and_selection(query)} #{
+      short_method(query.method, Enum.count(query.result))
+    } #{result_expectation(query.result)}.
     """
   end
 
   @doc """
   Extracts the selector from the query
   """
-  @spec selector(Query.t) :: String.t
+  @spec selector(Query.t()) :: String.t()
 
   def selector(%Query{selector: {name, value}}) do
     "'#{name}' with value '#{value}'"
   end
+
   def selector(%Query{selector: selector}) do
     "'#{selector}'"
   end
@@ -98,12 +114,13 @@ defmodule Wallaby.Query.ErrorMessage do
   Extracts the selector method from the selector and converts it into a human
   readable format
   """
-  @spec method(Query.t) :: String.t
-  @spec method({atom(), boolean()}) :: String.t
+  @spec method(Query.t()) :: String.t()
+  @spec method({atom(), boolean()}) :: String.t()
 
   def method(%Query{conditions: conditions} = query) do
     method(query.method, conditions[:count] > 1)
   end
+
   def method(_), do: "element"
 
   def method(:css, true), do: "elements that matched the css"
@@ -142,9 +159,9 @@ defmodule Wallaby.Query.ErrorMessage do
   def method(:attribute, true), do: "elements with the attribute"
   def method(:attribute, false), do: "element with the attribute"
 
-  def short_method(:css, count) when count > 1,  do: "elements"
+  def short_method(:css, count) when count > 1, do: "elements"
   def short_method(:css, count) when count == 0, do: "elements"
-  def short_method(:css, _),                 do: "element"
+  def short_method(:css, _), do: "element"
 
   def short_method(:xpath, count) when count == 1, do: "element"
   def short_method(:xpath, _), do: "elements"
@@ -154,27 +171,28 @@ defmodule Wallaby.Query.ErrorMessage do
   @doc """
   Generates failure conditions based on query conditions.
   """
-  @spec conditions(Keyword.t) :: list(String.t)
+  @spec conditions(Keyword.t()) :: list(String.t())
 
   def conditions(opts) do
     opts
     |> Keyword.delete(:visible)
     |> Keyword.delete(:count)
     |> Enum.map(&condition/1)
-    |> Enum.reject(& &1 == nil)
+    |> Enum.reject(&(&1 == nil))
   end
 
   @doc """
   Converts a condition into a human readable failure message.
   """
-  @spec condition({atom(), String.t}) :: String.t | nil
+  @spec condition({atom(), String.t()}) :: String.t() | nil
 
   def condition({:text, text}) when is_binary(text) do
     "text: '#{text}'"
   end
+
   def condition(_), do: nil
 
-  @spec visibility_and_selection(Query.t) :: String.t
+  @spec visibility_and_selection(Query.t()) :: String.t()
   defp visibility_and_selection(query) do
     case Query.selected?(query) do
       true -> "#{visibility(query)}, selected"
@@ -186,7 +204,7 @@ defmodule Wallaby.Query.ErrorMessage do
   @doc """
   Converts the visibilty attribute into a human readable form.
   """
-  @spec visibility(Query.t) :: String.t
+  @spec visibility(Query.t()) :: String.t()
 
   def visibility(query) do
     case Query.visible?(query) do
@@ -215,7 +233,8 @@ defmodule Wallaby.Query.ErrorMessage do
       conditions[:maximum] && Enum.count(query.result) > conditions[:maximum] ->
         "no more then #{conditions[:maximum]}"
 
-      true -> ""
+      true ->
+        ""
     end
   end
 

--- a/lib/wallaby/query/xpath.ex
+++ b/lib/wallaby/query/xpath.ex
@@ -2,10 +2,10 @@ defmodule Wallaby.Query.XPath do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Readability.MaxLineLength
 
-  @type query :: String.t
-  @type xpath :: String.t
-  @type name  :: query
-  @type id    :: query
+  @type query :: String.t()
+  @type xpath :: String.t()
+  @type name :: query
+  @type id :: query
   @type label :: query
 
   @doc """
@@ -14,7 +14,9 @@ defmodule Wallaby.Query.XPath do
   https://github.com/jnicklas/xpath/blob/master/lib/xpath/html.rb
   """
   def link(lnk) do
-    ~s{.//a[./@href][(((./@id = "#{lnk}" or contains(normalize-space(string(.)), "#{lnk}")) or contains(./@title, "#{lnk}")) or .//img[contains(./@alt, "#{lnk}")])]}
+    ~s{.//a[./@href][(((./@id = "#{lnk}" or contains(normalize-space(string(.)), "#{lnk}")) or contains(./@title, "#{
+      lnk
+    }")) or .//img[contains(./@alt, "#{lnk}")])]}
   end
 
   @doc """
@@ -22,7 +24,11 @@ defmodule Wallaby.Query.XPath do
   """
   def button(query) do
     types = "./@type = 'submit' or ./@type = 'reset' or ./@type = 'button' or ./@type = 'image'"
-    locator = ~s{(((./@id = "#{query}" or ./@name = "#{query}" or ./@value = "#{query}" or ./@alt = "#{query}" or ./@title = "#{query}" or contains(normalize-space(string(.)), "#{query}"))))}
+
+    locator =
+      ~s{(((./@id = "#{query}" or ./@name = "#{query}" or ./@value = "#{query}" or ./@alt = "#{
+        query
+      }" or ./@title = "#{query}" or contains(normalize-space(string(.)), "#{query}"))))}
 
     ~s{.//input[#{types}][#{locator}] | .//button[(not(./@type) or #{types})][#{locator}]}
   end
@@ -31,7 +37,11 @@ defmodule Wallaby.Query.XPath do
   Match any radio buttons
   """
   def radio_button(query) do
-    ~s{.//input[./@type = 'radio'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "radio"]}
+    ~s{.//input[./@type = 'radio'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{
+      query
+    }") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{
+      query
+    }")]//.//input[./@type = "radio"]}
   end
 
   @doc """
@@ -40,21 +50,33 @@ defmodule Wallaby.Query.XPath do
   `hidden`, or `file`.
   """
   def fillable_field(query) when is_binary(query) do
-    ~s{.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]}
+    ~s{.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')][(((./@id = "#{
+      query
+    }" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{
+      query
+    }")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//*[self::input | self::textarea][not(./@type = 'submit' or ./@type = 'image' or ./@type = 'radio' or ./@type = 'checkbox' or ./@type = 'hidden' or ./@type = 'file')]}
   end
 
   @doc """
   Match any checkboxes
   """
   def checkbox(query) do
-    ~s{.//input[./@type = 'checkbox'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{query}") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = "checkbox"]}
+    ~s{.//input[./@type = 'checkbox'][(((./@id = "#{query}" or ./@name = "#{query}") or ./@placeholder = "#{
+      query
+    }") or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{
+      query
+    }")]//.//input[./@type = "checkbox"]}
   end
 
   @doc """
   Match any `select` by name, id, or label.
   """
   def select(query) do
-    ~s{.//select[(((./@id = "#{query}" or ./@name = "#{query}")) or ./@name = //label[contains(normalize-space(string(.)), "#{query}")]/@for or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//select}
+    ~s{.//select[(((./@id = "#{query}" or ./@name = "#{query}")) or ./@name = //label[contains(normalize-space(string(.)), "#{
+      query
+    }")]/@for or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{
+      query
+    }")]//.//select}
   end
 
   @doc """
@@ -68,7 +90,9 @@ defmodule Wallaby.Query.XPath do
   Matches any file field by name, id, or label
   """
   def file_field(query) do
-    ~s{.//input[./@type = 'file'][(((./@id = "#{query}" or ./@name = "#{query}")) or ./@id = //label[contains(normalize-space(string(.)), "#{query}")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = 'file']}
+    ~s{.//input[./@type = 'file'][(((./@id = "#{query}" or ./@name = "#{query}")) or ./@id = //label[contains(normalize-space(string(.)), "#{
+      query
+    }")]/@for)] | .//label[contains(normalize-space(string(.)), "#{query}")]//.//input[./@type = 'file']}
   end
 
   @doc """

--- a/lib/wallaby/session.ex
+++ b/lib/wallaby/session.ex
@@ -2,13 +2,13 @@ defmodule Wallaby.Session do
   @moduledoc false
 
   @type t :: %__MODULE__{
-    id: String.t,
-    session_url: String.t,
-    url: String.t,
-    server: pid | :none,
-    screenshots: list,
-    driver: module,
-  }
+          id: String.t(),
+          session_url: String.t(),
+          url: String.t(),
+          server: pid | :none,
+          screenshots: list,
+          driver: module
+        }
 
   defstruct [:id, :url, :session_url, :driver, server: :none, screenshots: []]
 end

--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -22,11 +22,12 @@ defmodule Wallaby.SessionStore do
   end
 
   def handle_call({:demonitor, session}, _from, %{refs: refs} = state) do
-    case Enum.find(refs, fn({_, value}) -> value.id == session.id end) do
+    case Enum.find(refs, fn {_, value} -> value.id == session.id end) do
       {ref, _} ->
         {_, refs} = Map.pop(refs, ref)
         true = Process.demonitor(ref)
         {:reply, :ok, %{state | refs: refs}}
+
       nil ->
         {:reply, :ok, state}
     end
@@ -39,7 +40,7 @@ defmodule Wallaby.SessionStore do
   end
 
   def terminate(_reason, %{refs: refs}) do
-    Enum.each(refs, fn({_ref, session}) -> close_session(session) end)
+    Enum.each(refs, fn {_ref, session} -> close_session(session) end)
   end
 
   defp close_session(session) do

--- a/mix.exs
+++ b/mix.exs
@@ -7,36 +7,38 @@ defmodule Wallaby.Mixfile do
   @maintainers [
     "Chris Keathley",
     "Tobias Pfeiffer",
-    "Aaron Renner",
+    "Aaron Renner"
   ]
 
   def project do
-    [app: :wallaby,
-     version: @version,
-     elixir: "~> 1.5",
-     elixirc_paths: elixirc_paths(Mix.env),
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     package: package(),
-     description: "Concurrent feature tests for elixir",
-     deps: deps(),
-     docs: docs(),
+    [
+      app: :wallaby,
+      version: @version,
+      elixir: "~> 1.5",
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      package: package(),
+      description: "Concurrent feature tests for elixir",
+      deps: deps(),
+      docs: docs(),
 
-     # Custom testing
-     aliases: ["test.all": ["test", "test.drivers"],
-               "test.drivers": &test_drivers/1],
-     preferred_cli_env: [
-       coveralls: :test,
-       "coveralls.detail": :test,
-       "coveralls.post": :test,
-       "coveralls.html": :test,
-       "coveralls.travis": :test,
-       "coveralls.safe_travis": :test,
-       "test.all": :test,
-       "test.drivers": :test],
-     test_coverage: [tool: ExCoveralls],
-     test_paths: test_paths(@selected_driver),
-     dialyzer: [plt_add_apps: [:inets], ignore_warnings: "dialyzer.ignore_warnings"]]
+      # Custom testing
+      aliases: ["test.all": ["test", "test.drivers"], "test.drivers": &test_drivers/1],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test,
+        "coveralls.travis": :test,
+        "coveralls.safe_travis": :test,
+        "test.all": :test,
+        "test.drivers": :test
+      ],
+      test_coverage: [tool: ExCoveralls],
+      test_paths: test_paths(@selected_driver),
+      dialyzer: [plt_add_apps: [:inets], ignore_warnings: "dialyzer.ignore_warnings"]
+    ]
   end
 
   def application do
@@ -45,8 +47,8 @@ defmodule Wallaby.Mixfile do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   # need the testserver in dev for benchmarks to run
-  defp elixirc_paths(:dev),  do: ["lib", "integration_test/support/test_server.ex"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(:dev), do: ["lib", "integration_test/support/test_server.ex"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp deps do
     [
@@ -58,9 +60,9 @@ defmodule Wallaby.Mixfile do
       {:benchee_html, "~> 0.3", only: :dev},
       {:credo, "~> 0.9", only: [:dev, :test], runtime: false},
       {:bypass, "~> 0.8", only: :test},
-      {:excoveralls, "~> 0.7",  only: :test},
+      {:excoveralls, "~> 0.7", only: :test},
       {:ex_doc, "~> 0.20", only: :docs},
-      {:inch_ex, "~> 0.5", only: :docs},
+      {:inch_ex, "~> 0.5", only: :docs}
     ]
   end
 
@@ -80,7 +82,7 @@ defmodule Wallaby.Mixfile do
       source_ref: "v#{@version}",
       source_url: "https://github.com/keathley/wallaby",
       main: "readme",
-      logo: "guides/images/icon.png",
+      logo: "guides/images/icon.png"
     ]
   end
 
@@ -92,12 +94,15 @@ defmodule Wallaby.Mixfile do
   end
 
   defp run_integration_test(driver, args) do
-    args = if IO.ANSI.enabled?, do: ["--color" | args], else: ["--no-color" | args]
+    args = if IO.ANSI.enabled?(), do: ["--color" | args], else: ["--no-color" | args]
 
-    IO.puts "==> Running tests for WALLABY_DRIVER=#{driver} mix test"
-    {_, res} = System.cmd "mix", ["test" | args],
-                          into: IO.binstream(:stdio, :line),
-                          env: [{"WALLABY_DRIVER", driver}]
+    IO.puts("==> Running tests for WALLABY_DRIVER=#{driver} mix test")
+
+    {_, res} =
+      System.cmd("mix", ["test" | args],
+        into: IO.binstream(:stdio, :line),
+        env: [{"WALLABY_DRIVER", driver}]
+      )
 
     if res > 0 do
       System.at_exit(fn _ -> exit({:shutdown, 1}) end)

--- a/test/support/http_client_case.ex
+++ b/test/support/http_client_case.ex
@@ -14,13 +14,14 @@ defmodule Wallaby.HttpClientCase do
   Starts a bypass session and inserts it into the test session
   """
   def start_bypass(_) do
-    {:ok, bypass: Bypass.open}
+    {:ok, bypass: Bypass.open()}
   end
 
   @doc """
   Builds a url from the current bypass session
   """
   def bypass_url(bypass), do: "http://localhost:#{bypass.port}"
+
   def bypass_url(bypass, path) do
     "#{bypass_url(bypass)}#{path}"
   end

--- a/test/support/settings_test_helpers.ex
+++ b/test/support/settings_test_helpers.ex
@@ -11,11 +11,12 @@ defmodule Wallaby.SettingsTestHelpers do
   def ensure_setting_is_reset(app, setting) do
     orig_result = Application.fetch_env(app, setting)
 
-    on_exit fn -> reset_env(orig_result, app, setting) end
+    on_exit(fn -> reset_env(orig_result, app, setting) end)
   end
 
   defp reset_env({:ok, orig}, app, setting) do
     Application.put_env(app, setting, orig)
   end
+
   defp reset_env(:error, app, setting), do: Application.delete_env(app, setting)
 end

--- a/test/wallaby/browser_test.exs
+++ b/test/wallaby/browser_test.exs
@@ -8,32 +8,32 @@ defmodule Wallaby.BrowserTest do
   alias Wallaby.Session
 
   defmodule TestDriver do
-
     def start_link() do
       Agent.start_link(fn -> [] end, name: __MODULE__)
     end
 
     def visit(%Session{} = session, path) do
-      Agent.update(__MODULE__, fn (visits) ->
+      Agent.update(__MODULE__, fn visits ->
         [path | visits]
       end)
+
       session
     end
 
     def assert_visited(url) do
       unless Enum.member?(visits(), url) do
         raise ExUnit.AssertionError,
-          """
-          #{inspect url} was not visited.
+              """
+              #{inspect(url)} was not visited.
 
-          Visited urls:
-          #{visits() |> Enum.map(&"  #{inspect &1}") |> Enum.join("\n")}
-          """
+              Visited urls:
+              #{visits() |> Enum.map(&"  #{inspect(&1)}") |> Enum.join("\n")}
+              """
       end
     end
 
     defp visits do
-      Agent.get(__MODULE__, fn (visits) -> visits end)
+      Agent.get(__MODULE__, fn visits -> visits end)
     end
   end
 
@@ -129,11 +129,11 @@ defmodule Wallaby.BrowserTest do
 
       run_query = fn ->
         Agent.get_and_update(agent, fn initial ->
-            {initial, {:ok, []}}
+          {initial, {:ok, []}}
         end)
       end
 
-      assert Browser.retry run_query
+      assert Browser.retry(run_query)
     end
 
     test "it retries until time runs out" do

--- a/test/wallaby/driver/process_workspace_test.exs
+++ b/test/wallaby/driver/process_workspace_test.exs
@@ -31,8 +31,7 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       workspace_path = gen_tmp_path()
       File.mkdir(workspace_path)
       {:ok, test_server} = TestServer.start_link()
-      {:ok, ^workspace_path} =
-        ProcessWorkspace.create(test_server, workspace_path)
+      {:ok, ^workspace_path} = ProcessWorkspace.create(test_server, workspace_path)
 
       assert File.exists?(workspace_path)
 
@@ -47,8 +46,7 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       {:ok, workspace_path} = ProcessWorkspace.create(test_server)
 
       expected_path_prefix =
-        Path.join(
-          System.tmp_dir!, Application.get_env(:wallaby, :tmp_dir_prefix, ""))
+        Path.join(System.tmp_dir!(), Application.get_env(:wallaby, :tmp_dir_prefix, ""))
 
       assert workspace_path =~ ~r(^#{expected_path_prefix})
     end
@@ -58,7 +56,8 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
     base_dir =
       Path.join(
         System.tmp_dir!(),
-        Application.get_env(:wallaby, :tmp_dir_prefix, ""))
+        Application.get_env(:wallaby, :tmp_dir_prefix, "")
+      )
 
     TemporaryPath.generate(base_dir)
   end

--- a/test/wallaby/experimental/chrome/logger_test.exs
+++ b/test/wallaby/experimental/chrome/logger_test.exs
@@ -9,7 +9,7 @@ defmodule Wallaby.Experimental.Chrome.LoggerTest do
     test "removes line numbers from the end of INFO logs" do
       fun = fn ->
         build_log(~s(http://localhost:52615/logs.html 13:14 "test"))
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "test\n"
@@ -18,14 +18,14 @@ defmodule Wallaby.Experimental.Chrome.LoggerTest do
     test "prints non-string data types" do
       fun = fn ->
         build_log(~s(http://localhost:52615/logs.html 13:14 1))
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "1\n"
 
       fun = fn ->
         build_log(~s[http://localhost:52615/logs.html 13:14 Array(2)])
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "Array(2)\n"
@@ -34,22 +34,24 @@ defmodule Wallaby.Experimental.Chrome.LoggerTest do
     test "prints messages with embedded newlines" do
       fun = fn ->
         build_log(~s[http://localhost:52615/logs.html 13:14 "test\nlog"])
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "\"test\nlog\"\n"
     end
 
     test "pretty prints json" do
-      message = ~s(http://localhost:54579/logs.html 13:14 "{\"href\":\"http://localhost:54579/logs.html\",\"ancestorOrigins\":{}}")
+      message =
+        ~s(http://localhost:54579/logs.html 13:14 "{\"href\":\"http://localhost:54579/logs.html\",\"ancestorOrigins\":{}}")
 
       fun = fn ->
         message
         |> build_log
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
-      assert capture_io(fun) == "\n{\n  \"ancestorOrigins\": {},\n  \"href\": \"http://localhost:54579/logs.html\"\n}\n"
+      assert capture_io(fun) ==
+               "\n{\n  \"ancestorOrigins\": {},\n  \"href\": \"http://localhost:54579/logs.html\"\n}\n"
     end
 
     test "can be disabled" do
@@ -59,7 +61,7 @@ defmodule Wallaby.Experimental.Chrome.LoggerTest do
       fun = fn ->
         "test log"
         |> build_log()
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == ""

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -10,12 +10,13 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the webdriver backend", %{bypass: bypass} do
       base_url = bypass_url(bypass) <> "/"
       new_session_id = "abc123"
+
       capabilities = %{
         "platform" => "OS X",
         "browser" => "chrome"
       }
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert "POST" == conn.method
         assert "/session" == conn.request_path
         assert %{"desiredCapabilities" => capabilities} == conn.body_params
@@ -28,17 +29,18 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "browserName": "phantomjs"
           }
         }>)
-      end
+      end)
 
       assert {:ok, response} = Client.create_session(base_url, capabilities)
-      assert %{"sessionId" => ^new_session_id} =  response
+      assert %{"sessionId" => ^new_session_id} = response
     end
   end
 
   describe "delete_session/1" do
     test "sends a delete request to Session.session_url", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      handle_request bypass, fn conn ->
+
+      handle_request(bypass, fn conn ->
         assert "DELETE" == conn.method
         assert "/session/#{session.id}" == conn.request_path
 
@@ -47,14 +49,15 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, response} = Client.delete_session(session)
+
       assert response == %{
-        "sessionId" => session.id,
-        "status" => 0,
-        "value" => %{},
-      }
+               "sessionId" => session.id,
+               "status" => 0,
+               "value" => %{}
+             }
     end
   end
 
@@ -62,9 +65,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "with a Session as the parent", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       element_id = ":wdc:1491326583887"
-      query = ".blue" |> Query.css |> Query.compile
+      query = ".blue" |> Query.css() |> Query.compile()
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/elements"
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
@@ -74,25 +77,26 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": [{"ELEMENT": "#{element_id}"}]
         }>)
-      end
+      end)
 
       assert {:ok, [element]} = Client.find_elements(session, query)
+
       assert element == %Element{
-        id: element_id,
-        parent: session,
-        session_url: session.url,
-        url: "#{session.url}/element/#{element_id}",
-        driver: Wallaby.Experimental.Selenium,
-      }
+               id: element_id,
+               parent: session,
+               session_url: session.url,
+               url: "#{session.url}/element/#{element_id}",
+               driver: Wallaby.Experimental.Selenium
+             }
     end
 
     test "with an Element as the parent", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       parent_element = build_element_for_session(session)
       element_id = ":wdc:1491326583887"
-      query = ".blue" |> Query.css |> Query.compile
+      query = ".blue" |> Query.css() |> Query.compile()
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{parent_element.id}/elements"
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
@@ -102,24 +106,25 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": [{"ELEMENT": "#{element_id}"}]
         }>)
-      end
+      end)
 
       assert {:ok, [element]} = Client.find_elements(parent_element, query)
+
       assert element == %Element{
-        id: element_id,
-        parent: parent_element,
-        session_url: session.url,
-        url: "#{session.url}/element/#{element_id}",
-        driver: Wallaby.Experimental.Selenium,
-      }
+               id: element_id,
+               parent: parent_element,
+               session_url: session.url,
+               url: "#{session.url}/element/#{element_id}",
+               driver: Wallaby.Experimental.Selenium
+             }
     end
 
     test "with newer web element identifier", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       element_id = ":wdc:1491326583887"
-      query = ".blue" |> Query.css |> Query.compile
+      query = ".blue" |> Query.css() |> Query.compile()
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/elements"
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
@@ -129,16 +134,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": [{"#{@web_element_identifier}": "#{element_id}"}]
         }>)
-      end
+      end)
 
       assert {:ok, [element]} = Client.find_elements(session, query)
+
       assert element == %Element{
-        id: element_id,
-        parent: session,
-        session_url: session.url,
-        url: "#{session.url}/element/#{element_id}",
-        driver: Wallaby.Experimental.Selenium,
-      }
+               id: element_id,
+               parent: session,
+               session_url: session.url,
+               url: "#{session.url}/element/#{element_id}",
+               driver: Wallaby.Experimental.Selenium
+             }
     end
   end
 
@@ -148,7 +154,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       value = "hello world"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/value"
         assert conn.body_params == %{"value" => [value]}
@@ -158,7 +164,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": null
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.set_value(element, value)
     end
@@ -168,12 +174,12 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       value = "hello world"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.set_value(element, value)
     end
@@ -183,9 +189,9 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       value = "hello world"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         send_resp(conn, 204, "")
-      end
+      end)
 
       assert {:ok, nil} = Client.set_value(element, value)
     end
@@ -195,7 +201,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       value = "hello world"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         send_resp(conn, 500, ~s<{
           "sessionId": "#{session.id}",
           "status": null,
@@ -203,7 +209,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "class": "org.openqa.selenium.StaleElementReferenceException"
           }
         }>)
-      end
+      end)
 
       assert {:error, :stale_reference} = Client.set_value(element, value)
     end
@@ -214,7 +220,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/clear"
 
@@ -223,7 +229,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": null
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.clear(element)
     end
@@ -232,7 +238,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/clear"
 
@@ -240,7 +246,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "sessionId": "#{session.id}",
           "status": 0
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.clear(element)
     end
@@ -249,12 +255,12 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/clear"
 
         send_resp(conn, 204, "")
-      end
+      end)
 
       assert {:ok, nil} = Client.clear(element)
     end
@@ -263,7 +269,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/clear"
 
@@ -274,7 +280,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "class": "org.openqa.selenium.StaleElementReferenceException"
           }
         }>)
-      end
+      end)
 
       assert {:error, :stale_reference} = Client.clear(element)
     end
@@ -285,7 +291,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/click"
 
@@ -294,7 +300,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.click(element)
     end
@@ -305,7 +311,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/text"
 
@@ -314,7 +320,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": ""
         }>)
-      end
+      end)
 
       assert {:ok, ""} = Client.text(element)
     end
@@ -325,7 +331,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       page_title = "Wallaby rocks"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/title"
 
@@ -334,7 +340,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "#{page_title}"
         }>)
-      end
+      end)
 
       assert {:ok, ^page_title} = Client.page_title(session)
     end
@@ -346,16 +352,18 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       attribute_name = "name"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
-        assert conn.request_path == "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}"
+
+        assert conn.request_path ==
+                 "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}"
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": "password"
         }>)
-      end
+      end)
 
       assert {:ok, "password"} = Client.attribute(element, "name")
     end
@@ -366,7 +374,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/url"
         assert conn.body_params == %{"url" => url}
@@ -376,7 +384,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert :ok = Client.visit(session, url)
     end
@@ -387,7 +395,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/url"
 
@@ -396,7 +404,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "#{url}"
         }>)
-      end
+      end)
 
       assert {:ok, ^url} = Client.current_url(session)
     end
@@ -407,7 +415,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com/search"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/url"
 
@@ -416,7 +424,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "#{url}"
         }>)
-      end
+      end)
 
       assert {:ok, "/search"} = Client.current_path(session)
     end
@@ -427,7 +435,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/selected"
 
@@ -436,7 +444,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": true
         }>)
-      end
+      end)
 
       assert {:ok, true} = Client.selected(element)
     end
@@ -447,7 +455,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed"
 
@@ -456,7 +464,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": true
         }>)
-      end
+      end)
 
       assert {:ok, true} = Client.displayed(element)
     end
@@ -465,7 +473,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed"
 
@@ -476,7 +484,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "class": "org.openqa.selenium.StaleElementReferenceException"
           }
         }>)
-      end
+      end)
 
       assert {:error, :stale_reference} = Client.displayed(element)
     end
@@ -487,7 +495,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/size"
 
@@ -496,7 +504,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "not quite sure"
         }>)
-      end
+      end)
 
       assert {:ok, "not quite sure"} = Client.size(element)
     end
@@ -507,7 +515,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/rect"
 
@@ -516,7 +524,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "not quite sure"
         }>)
-      end
+      end)
 
       assert {:ok, "not quite sure"} = Client.rect(element)
     end
@@ -527,7 +535,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       screenshot_data = ":)"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/screenshot"
 
@@ -536,7 +544,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "#{Base.encode64(screenshot_data)}"
         }>)
-      end
+      end)
 
       assert ^screenshot_data = Client.take_screenshot(session)
     end
@@ -546,7 +554,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/cookie"
 
@@ -555,7 +563,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": [{"domain": "localhost"}]
         }>)
-      end
+      end)
 
       assert {:ok, [%{"domain" => "localhost"}]} = Client.cookies(session)
     end
@@ -567,7 +575,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       key = "tester"
       value = "McTestington"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/cookie"
         assert conn.body_params == %{"cookie" => %{"name" => key, "value" => value}}
@@ -577,7 +585,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": []
         }>)
-      end
+      end)
 
       assert {:ok, []} = Client.set_cookie(session, key, value)
     end
@@ -589,7 +597,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       height = 600
       width = 400
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/window/current/size"
         assert conn.body_params == %{"height" => height, "width" => width}
@@ -599,7 +607,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.set_window_size(session, width, height)
     end
@@ -609,7 +617,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/window/current/size"
 
@@ -621,7 +629,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "width": 400
           }
         }>)
-      end
+      end)
 
       assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session)
     end
@@ -633,7 +641,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       x_coordinate = 600
       y_coordinate = 400
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/window/current/position"
         assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
@@ -643,7 +651,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.set_window_position(session, x_coordinate, y_coordinate)
     end
@@ -653,7 +661,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/window/current/position"
 
@@ -665,7 +673,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
             "y": 400
           }
         }>)
-      end
+      end)
 
       assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session)
     end
@@ -675,7 +683,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/window/current/maximize"
 
@@ -684,7 +692,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} == Client.maximize_window(session)
     end
@@ -694,19 +702,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/execute"
-        assert conn.body_params == %{
-        "script" => "localStorage.clear()",
-        "args" => [2, "a"]}
+        assert conn.body_params == %{"script" => "localStorage.clear()", "args" => [2, "a"]}
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": null
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.execute_script(session, "localStorage.clear()", [2, "a"])
     end
@@ -717,17 +723,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       keys = ["abc", :tab]
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/keys"
-        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!
+        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
         resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": null
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.send_keys(session, keys)
     end
@@ -737,17 +743,17 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       element = build_element_for_session(session)
       keys = ["abc", :tab]
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/element/#{element.id}/value"
-        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!
+        assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
         resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": null
         }>)
-      end
+      end)
 
       assert {:ok, nil} = Client.send_keys(element, keys)
     end
@@ -757,7 +763,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/log"
         assert conn.body_params == %{"type" => "browser"}
@@ -767,7 +773,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": []
         }>)
-      end
+      end)
 
       assert {:ok, []} = Client.log(session)
     end
@@ -778,7 +784,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       page_source = "<html></html>"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/source"
 
@@ -787,7 +793,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "#{page_source}"
         }>)
-      end
+      end)
 
       assert {:ok, ^page_source} = Client.page_source(session)
     end
@@ -797,7 +803,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/window_handles"
 
@@ -806,7 +812,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": ["some-window-handle", "other-window-handle"]
         }>)
-      end
+      end)
 
       assert {:ok, ["some-window-handle", "other-window-handle"]} = Client.window_handles(session)
     end
@@ -816,7 +822,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "GET"
         assert conn.request_path == "/session/#{session.id}/window_handle"
 
@@ -825,7 +831,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": "my-window-handle"
         }>)
-      end
+      end)
 
       assert {:ok, "my-window-handle"} = Client.window_handle(session)
     end
@@ -836,7 +842,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       window_handle_id = "my-window-handle"
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/window"
         assert conn.body_params == %{"name" => window_handle_id, "handle" => window_handle_id}
@@ -846,7 +852,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.focus_window(session, window_handle_id)
     end
@@ -856,7 +862,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "DELETE"
         assert conn.request_path == "/session/#{session.id}/window"
 
@@ -865,7 +871,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.close_window(session)
     end
@@ -876,26 +882,34 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       frame_element = build_element_for_session(session, "frame-element-id")
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/frame"
-        assert conn.body_params == %{"id" => %{"ELEMENT" => frame_element.id, @web_element_identifier => frame_element.id}}
+
+        assert conn.body_params == %{
+                 "id" => %{
+                   "ELEMENT" => frame_element.id,
+                   @web_element_identifier => frame_element.id
+                 }
+               }
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_element)
     end
 
-    test "sends the correct request to the server when switching to default frame", %{bypass: bypass} do
+    test "sends the correct request to the server when switching to default frame", %{
+      bypass: bypass
+    } do
       session = build_session_for_bypass(bypass)
       frame_id = nil
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/frame"
         assert conn.body_params == %{"id" => frame_id}
@@ -905,17 +919,16 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_id)
     end
-
 
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       frame_id = 1
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/frame"
         assert conn.body_params == %{"id" => frame_id}
@@ -925,7 +938,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_id)
     end
@@ -935,7 +948,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/frame/parent"
 
@@ -944,7 +957,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.focus_parent_frame(session)
     end
@@ -955,7 +968,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/moveto"
         assert conn.body_params == %{"element" => element.id}
@@ -965,16 +978,18 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.move_mouse_to(nil, element)
     end
 
-    test "sends the correct request to the server when session and offsets are given", %{bypass: bypass} do
+    test "sends the correct request to the server when session and offsets are given", %{
+      bypass: bypass
+    } do
       session = build_session_for_bypass(bypass)
       {x_offset, y_offset} = {20, 30}
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/moveto"
         assert conn.body_params == %{"xoffset" => x_offset, "yoffset" => y_offset}
@@ -984,27 +999,34 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.move_mouse_to(session, nil, x_offset, y_offset)
     end
 
-    test "sends the correct request to the server when element and offsets are given", %{bypass: bypass} do
+    test "sends the correct request to the server when element and offsets are given", %{
+      bypass: bypass
+    } do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
       {x_offset, y_offset} = {20, 30}
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/moveto"
-        assert conn.body_params == %{"element" => element.id, "xoffset" => x_offset, "yoffset" => y_offset}
+
+        assert conn.body_params == %{
+                 "element" => element.id,
+                 "xoffset" => x_offset,
+                 "yoffset" => y_offset
+               }
 
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.move_mouse_to(nil, element, x_offset, y_offset)
     end
@@ -1014,7 +1036,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/click"
         assert conn.body_params == %{"button" => 0}
@@ -1024,7 +1046,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.click(session, :left)
     end
@@ -1034,7 +1056,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/doubleclick"
 
@@ -1043,7 +1065,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.double_click(session)
     end
@@ -1053,7 +1075,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/buttondown"
         assert conn.body_params == %{"button" => 0}
@@ -1063,7 +1085,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.button_down(session, :left)
     end
@@ -1073,7 +1095,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      handle_request bypass, fn conn ->
+      handle_request(bypass, fn conn ->
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/buttonup"
         assert conn.body_params == %{"button" => 0}
@@ -1083,22 +1105,27 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, %{}} = Client.button_up(session, :left)
     end
   end
 
   defp handle_request(bypass, handler_fn) do
-    Bypass.expect bypass, fn conn ->
+    Bypass.expect(bypass, fn conn ->
       conn |> parse_body |> handler_fn.()
-    end
+    end)
   end
 
   defp build_session_for_bypass(bypass, session_id \\ "my-sample-session") do
     session_url = bypass_url(bypass, "/session/#{session_id}")
 
-    %Session{driver: Wallaby.Experimental.Selenium, id: session_id, session_url: session_url, url: session_url}
+    %Session{
+      driver: Wallaby.Experimental.Selenium,
+      id: session_id,
+      session_url: session_url,
+      url: session_url
+    }
   end
 
   defp build_element_for_session(session, element_id \\ ":wdc:abc123") do
@@ -1107,7 +1134,7 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       id: element_id,
       parent: session,
       session_url: session.url,
-      url: "#{session.url}/element/#{element_id}",
+      url: "#{session.url}/element/#{element_id}"
     }
   end
 end

--- a/test/wallaby/experimental/selenium_test.exs
+++ b/test/wallaby/experimental/selenium_test.exs
@@ -7,8 +7,9 @@ defmodule Wallaby.Experimental.SeleniumTest do
     test "starts a selenium session with the default url" do
       session_id = "abc123"
       test_pid = self()
+
       create_session_fn = fn base_url, capabilities ->
-        send test_pid, {:fn_called, [base_url, capabilities]}
+        send(test_pid, {:fn_called, [base_url, capabilities]})
 
         {:ok, %{"sessionId" => session_id}}
       end
@@ -16,12 +17,12 @@ defmodule Wallaby.Experimental.SeleniumTest do
       {:ok, session} = Selenium.start_session(create_session_fn: create_session_fn)
 
       assert session == %Wallaby.Session{
-        session_url: "http://localhost:4444/wd/hub/session/#{session_id}",
-        url: "http://localhost:4444/wd/hub/session/#{session_id}",
-        id: session_id,
-        server: :none,
-        driver: Wallaby.Experimental.Selenium
-      }
+               session_url: "http://localhost:4444/wd/hub/session/#{session_id}",
+               url: "http://localhost:4444/wd/hub/session/#{session_id}",
+               id: session_id,
+               server: :none,
+               driver: Wallaby.Experimental.Selenium
+             }
 
       assert_received {:fn_called, ["http://localhost:4444/wd/hub/", %{javascriptEnabled: true}]}
     end
@@ -33,7 +34,7 @@ defmodule Wallaby.Experimental.SeleniumTest do
       end
 
       assert {:error, %HTTPoison.Error{reason: :nxdomain}} =
-        Selenium.start_session(create_session_fn: create_session_fn)
+               Selenium.start_session(create_session_fn: create_session_fn)
     end
   end
 
@@ -41,8 +42,9 @@ defmodule Wallaby.Experimental.SeleniumTest do
     test "sends the end session" do
       session = build_session()
       test_pid = self()
+
       end_session_fn = fn session ->
-        send test_pid, {:fn_called, session}
+        send(test_pid, {:fn_called, session})
         :ok
       end
 
@@ -54,6 +56,7 @@ defmodule Wallaby.Experimental.SeleniumTest do
 
   defp build_session do
     session_id = random_string(24)
+
     %Wallaby.Session{
       session_url: "http://localhost:4444/wd/hub/session/#{session_id}",
       url: "http://localhost:4444/wd/hub/session/#{session_id}",
@@ -63,6 +66,6 @@ defmodule Wallaby.Experimental.SeleniumTest do
   end
 
   defp random_string(length) do
-    :crypto.strong_rand_bytes(length) |> Base.url_encode64 |> binary_part(0, length)
+    :crypto.strong_rand_bytes(length) |> Base.url_encode64() |> binary_part(0, length)
   end
 end

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -10,12 +10,13 @@ defmodule Wallaby.Phantom.DriverTest do
     test "sends the correct request to the webdriver backend", %{bypass: bypass} do
       base_url = bypass_url(bypass) <> "/"
       new_session_id = "abc123"
+
       capabilities = %{
         "platform" => "OS X",
         "browser" => "chrome"
       }
 
-      Bypass.expect bypass, fn conn ->
+      Bypass.expect(bypass, fn conn ->
         conn = parse_body(conn)
         assert "POST" == conn.method
         assert "/session" == conn.request_path
@@ -29,17 +30,18 @@ defmodule Wallaby.Phantom.DriverTest do
             "browserName": "phantomjs"
           }
         }>)
-      end
+      end)
 
       assert {:ok, response} = Driver.create_session(base_url, capabilities)
-      assert %{"sessionId" => ^new_session_id} =  response
+      assert %{"sessionId" => ^new_session_id} = response
     end
   end
 
   describe "delete/1" do
     test "sends a delete request to Session.session_url", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      Bypass.expect bypass, fn conn ->
+
+      Bypass.expect(bypass, fn conn ->
         assert "DELETE" == conn.method
         assert "/session/#{session.id}" == conn.request_path
 
@@ -48,14 +50,15 @@ defmodule Wallaby.Phantom.DriverTest do
           "status": 0,
           "value": {}
         }>)
-      end
+      end)
 
       assert {:ok, response} = Driver.delete(session)
+
       assert response == %{
-        "sessionId" => session.id,
-        "status" => 0,
-        "value" => %{},
-      }
+               "sessionId" => session.id,
+               "status" => 0,
+               "value" => %{}
+             }
     end
   end
 
@@ -63,9 +66,9 @@ defmodule Wallaby.Phantom.DriverTest do
     test "with a Session as the parent", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       element_id = ":wdc:1491326583887"
-      query = ".blue" |> Query.css |> Query.compile
+      query = ".blue" |> Query.css() |> Query.compile()
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" && conn.request_path == "/session/#{session.id}/elements" do
           assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
@@ -75,27 +78,28 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": [{"ELEMENT": "#{element_id}"}]
           }>)
         end
-      end
+      end)
 
       assert {:ok, [element]} = Driver.find_elements(session, query)
+
       assert element == %Element{
-        driver: Phantom,
-        id: element_id,
-        parent: session,
-        session_url: session.url,
-        url: "#{session.url}/element/#{element_id}",
-      }
+               driver: Phantom,
+               id: element_id,
+               parent: session,
+               session_url: session.url,
+               url: "#{session.url}/element/#{element_id}"
+             }
     end
 
     test "with an Element as the parent", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
       parent_element = build_element_for_session(session)
       element_id = ":wdc:1491326583887"
-      query = ".blue" |> Query.css |> Query.compile
+      query = ".blue" |> Query.css() |> Query.compile()
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/element/#{parent_element.id}/elements" do
+             conn.request_path == "/session/#{session.id}/element/#{parent_element.id}/elements" do
           assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
           send_resp(conn, 200, ~s<{
@@ -104,16 +108,17 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": [{"ELEMENT": "#{element_id}"}]
           }>)
         end
-      end
+      end)
 
       assert {:ok, [element]} = Driver.find_elements(parent_element, query)
+
       assert element == %Element{
-        driver: Phantom,
-        id: element_id,
-        parent: parent_element,
-        session_url: session.url,
-        url: "#{session.url}/element/#{element_id}",
-      }
+               driver: Phantom,
+               id: element_id,
+               parent: parent_element,
+               session_url: session.url,
+               url: "#{session.url}/element/#{element_id}"
+             }
     end
   end
 
@@ -123,10 +128,9 @@ defmodule Wallaby.Phantom.DriverTest do
       element = build_element_for_session(session)
       value = "hello world"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/value" do
-
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/value" do
           assert conn.body_params == %{"value" => [value]}
 
           send_resp(conn, 200, ~s<{
@@ -135,7 +139,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": null
           }>)
         end
-      end
+      end)
 
       assert {:ok, nil} = Driver.set_value(element, value)
     end
@@ -146,16 +150,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/clear" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/clear" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": null
           }>)
         end
-      end
+      end)
 
       assert {:ok, nil} = Driver.clear(element)
     end
@@ -166,16 +170,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/click" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/click" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": {}
           }>)
         end
-      end
+      end)
 
       assert {:ok, %{}} = Driver.click(element)
     end
@@ -186,16 +190,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/text" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/text" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": ""
           }>)
         end
-      end
+      end)
 
       assert {:ok, ""} = Driver.text(element)
     end
@@ -206,7 +210,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       page_title = "Wallaby rocks"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/title" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -214,7 +218,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": "#{page_title}"
           }>)
         end
-      end
+      end)
 
       assert {:ok, ^page_title} = Driver.page_title(session)
     end
@@ -226,16 +230,17 @@ defmodule Wallaby.Phantom.DriverTest do
       element = build_element_for_session(session)
       attribute_name = "name"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}" do
+             conn.request_path ==
+               "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": "password"
           }>)
         end
-      end
+      end)
 
       assert {:ok, "password"} = Driver.attribute(element, "name")
     end
@@ -246,7 +251,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" && conn.request_path == "/session/#{session.id}/url" do
           assert conn.body_params == %{"url" => url}
 
@@ -256,7 +261,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": {}
           }>)
         end
-      end
+      end)
 
       assert :ok = Driver.visit(session, url)
     end
@@ -265,13 +270,13 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" && conn.request_path == "/session/#{session.id}/url" do
           assert conn.body_params == %{"url" => url}
 
           send_resp(conn, 204, "")
         end
-      end
+      end)
 
       assert :ok = Driver.visit(session, url)
     end
@@ -282,7 +287,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/url" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -290,7 +295,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": "#{url}"
           }>)
         end
-      end
+      end)
 
       assert {:ok, ^url} = Driver.current_url(session)
     end
@@ -301,7 +306,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       url = "http://www.google.com/search"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/url" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -309,7 +314,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": "#{url}"
           }>)
         end
-      end
+      end)
 
       assert {:ok, "/search"} = Driver.current_path(session)
     end
@@ -320,16 +325,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/selected" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/selected" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": true
           }>)
         end
-      end
+      end)
 
       assert {:ok, true} = Driver.selected(element)
     end
@@ -340,16 +345,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": true
           }>)
         end
-      end
+      end)
 
       assert {:ok, true} = Driver.displayed(element)
     end
@@ -358,9 +363,9 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
           send_resp(conn, 500, ~s<{
             "sessionId": "#{session.id}",
             "status": 10,
@@ -369,7 +374,7 @@ defmodule Wallaby.Phantom.DriverTest do
             }
           }>)
         end
-      end
+      end)
 
       assert {:error, :stale_reference} = Driver.displayed(element)
     end
@@ -380,16 +385,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": true
           }>)
         end
-      end
+      end)
 
       assert true = Driver.displayed!(element)
     end
@@ -398,9 +403,9 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/displayed" do
           send_resp(conn, 500, ~s<{
             "sessionId": "#{session.id}",
             "status": 10,
@@ -409,7 +414,7 @@ defmodule Wallaby.Phantom.DriverTest do
             }
           }>)
         end
-      end
+      end)
 
       assert_raise StaleReferenceError, fn ->
         Driver.displayed!(element)
@@ -422,16 +427,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/size" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/size" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": "not quite sure"
           }>)
         end
-      end
+      end)
 
       assert {:ok, "not quite sure"} = Driver.size(element)
     end
@@ -442,16 +447,16 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       element = build_element_for_session(session)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/rect" do
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/rect" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
             "value": "not quite sure"
           }>)
         end
-      end
+      end)
 
       assert {:ok, "not quite sure"} = Driver.rect(element)
     end
@@ -462,7 +467,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       screenshot_data = ":)"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/screenshot" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -470,7 +475,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": "#{Base.encode64(screenshot_data)}"
           }>)
         end
-      end
+      end)
 
       assert ^screenshot_data = Driver.take_screenshot(session)
     end
@@ -480,7 +485,7 @@ defmodule Wallaby.Phantom.DriverTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/cookie" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -488,7 +493,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": [{"domain": "localhost"}]
           }>)
         end
-      end
+      end)
 
       assert {:ok, [%{"domain" => "localhost"}]} = Driver.cookies(session)
     end
@@ -500,7 +505,7 @@ defmodule Wallaby.Phantom.DriverTest do
       key = "tester"
       value = "McTestington"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" && conn.request_path == "/session/#{session.id}/cookie" do
           assert conn.body_params == %{"cookie" => %{"name" => key, "value" => value}}
 
@@ -510,7 +515,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": []
           }>)
         end
-      end
+      end)
 
       assert {:ok, []} = Driver.set_cookie(session, key, value)
     end
@@ -522,9 +527,9 @@ defmodule Wallaby.Phantom.DriverTest do
       height = 600
       width = 400
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/window/#{@window_handle_id}/size" do
+             conn.request_path == "/session/#{session.id}/window/#{@window_handle_id}/size" do
           assert conn.body_params == %{"height" => height, "width" => width}
 
           send_resp(conn, 200, ~s<{
@@ -533,7 +538,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": {}
           }>)
         end
-      end
+      end)
 
       assert {:ok, %{}} = Driver.set_window_size(session, width, height)
     end
@@ -543,10 +548,9 @@ defmodule Wallaby.Phantom.DriverTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" &&
-          conn.request_path == "/session/#{session.id}/window/#{@window_handle_id}/size" do
-
+             conn.request_path == "/session/#{session.id}/window/#{@window_handle_id}/size" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
             "status": 0,
@@ -556,7 +560,7 @@ defmodule Wallaby.Phantom.DriverTest do
             }
           }>)
         end
-      end
+      end)
 
       assert {:ok, %{}} = Driver.get_window_size(session)
     end
@@ -566,13 +570,10 @@ defmodule Wallaby.Phantom.DriverTest do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/execute" do
-          assert conn.body_params == %{
-          "script" => "localStorage.clear()",
-          "args" => [2, "a"]}
-
+             conn.request_path == "/session/#{session.id}/execute" do
+          assert conn.body_params == %{"script" => "localStorage.clear()", "args" => [2, "a"]}
 
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -580,7 +581,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": null
           }>)
         end
-      end
+      end)
 
       assert {:ok, nil} = Driver.execute_script(session, "localStorage.clear()", [2, "a"])
     end
@@ -591,9 +592,9 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       keys = ["abc", :tab]
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" && conn.request_path == "/session/#{session.id}/keys" do
-          assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!
+          assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
           resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -601,7 +602,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": null
           }>)
         end
-      end
+      end)
 
       assert {:ok, nil} = Driver.send_keys(session, keys)
     end
@@ -611,10 +612,10 @@ defmodule Wallaby.Phantom.DriverTest do
       element = build_element_for_session(session)
       keys = ["abc", :tab]
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "POST" &&
-          conn.request_path == "/session/#{session.id}/element/#{element.id}/value" do
-          assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!
+             conn.request_path == "/session/#{session.id}/element/#{element.id}/value" do
+          assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
           resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -622,7 +623,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": null
           }>)
         end
-      end
+      end)
 
       assert {:ok, nil} = Driver.send_keys(element, keys)
     end
@@ -631,7 +632,8 @@ defmodule Wallaby.Phantom.DriverTest do
   describe "log/1" do
     test "sends the correct request to the server", %{bypass: bypass} do
       session = build_session_for_bypass(bypass)
-      Bypass.expect bypass, fn conn ->
+
+      Bypass.expect(bypass, fn conn ->
         conn = parse_body(conn)
         assert conn.method == "POST"
         assert conn.request_path == "/session/#{session.id}/log"
@@ -642,7 +644,7 @@ defmodule Wallaby.Phantom.DriverTest do
           "status": 0,
           "value": []
         }>)
-      end
+      end)
 
       assert {:ok, []} = Driver.log(session)
     end
@@ -653,7 +655,7 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
       page_source = "<html></html>"
 
-      stub_backend bypass, session, fn conn ->
+      stub_backend(bypass, session, fn conn ->
         if conn.method == "GET" && conn.request_path == "/session/#{session.id}/source" do
           send_resp(conn, 200, ~s<{
             "sessionId": "#{session.id}",
@@ -661,7 +663,7 @@ defmodule Wallaby.Phantom.DriverTest do
             "value": "#{page_source}"
           }>)
         end
-      end
+      end)
 
       assert {:ok, ^page_source} = Driver.page_source(session)
     end
@@ -679,14 +681,14 @@ defmodule Wallaby.Phantom.DriverTest do
       id: element_id,
       parent: session,
       session_url: session.url,
-      url: "#{session.url}/element/#{element_id}",
+      url: "#{session.url}/element/#{element_id}"
     }
   end
 
   # Sets up bypass to run the given function and if no result is set, runs the
   # default routes.
   defp stub_backend(bypass, session, handle_fn) do
-    Bypass.expect bypass, fn conn ->
+    Bypass.expect(bypass, fn conn ->
       conn = parse_body(conn)
 
       case handle_fn.(conn) do
@@ -694,7 +696,7 @@ defmodule Wallaby.Phantom.DriverTest do
         %Plug.Conn{state: :sent} = conn -> conn
         _ -> handle_default_routes(conn, session)
       end
-    end
+    end)
   end
 
   defp handle_default_routes(conn, session) do
@@ -705,12 +707,14 @@ defmodule Wallaby.Phantom.DriverTest do
           "status": 0,
           "value": []
         }>)
+
       conn.method == "GET" && conn.request_path == "/session/#{session.id}/window_handle" ->
         send_resp(conn, 200, ~s<{
           "sessionId": "#{session.id}",
           "status": 0,
           "value": "#{@window_handle_id}"
         }>)
+
       true ->
         refute true, "Unhandled request #{conn.method} #{conn.request_path}"
     end

--- a/test/wallaby/phantom/log_store_test.exs
+++ b/test/wallaby/phantom/log_store_test.exs
@@ -3,9 +3,9 @@ defmodule Wallaby.Driver.LogStoreTest do
 
   alias Wallaby.Driver.LogStore
 
-  @l1 %{"level" => "INFO", "message" => "l1 (:)", "timestamp" => 1470795015152}
-  @l2 %{"level" => "INFO", "message" => "l2 (:)", "timestamp" => 1470795015290}
-  @l3 %{"level" => "WARNING", "message" => "l3 (:)", "timestamp" => 1470795015345}
+  @l1 %{"level" => "INFO", "message" => "l1 (:)", "timestamp" => 1_470_795_015_152}
+  @l2 %{"level" => "INFO", "message" => "l2 (:)", "timestamp" => 1_470_795_015_290}
+  @l3 %{"level" => "WARNING", "message" => "l3 (:)", "timestamp" => 1_470_795_015_345}
 
   @session "123abc"
 

--- a/test/wallaby/phantom/logger_test.exs
+++ b/test/wallaby/phantom/logger_test.exs
@@ -8,21 +8,21 @@ defmodule Wallaby.Phantom.LoggerTest do
     test "removes line numbers from the end of INFO logs" do
       fun = fn ->
         build_log("test (:)")
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "test\n"
 
       fun = fn ->
         build_log("test (undefined:undefined)")
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "test\n"
 
       fun = fn ->
         build_log("test (1:3) (:)")
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == "test (1:3)\n"
@@ -34,7 +34,7 @@ defmodule Wallaby.Phantom.LoggerTest do
       fun = fn ->
         "test log"
         |> build_log()
-        |> Logger.parse_log
+        |> Logger.parse_log()
       end
 
       assert capture_io(fun) == ""

--- a/test/wallaby/phantom/server/server_state_test.exs
+++ b/test/wallaby/phantom/server/server_state_test.exs
@@ -13,8 +13,8 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
 
     test "creates a new server state that's not running" do
       assert %ServerState{
-        workspace_path: "/tmp",
-      } = ServerState.new("/tmp")
+               workspace_path: "/tmp"
+             } = ServerState.new("/tmp")
     end
 
     test "creates a new server state with a prefilled port_number" do
@@ -24,8 +24,7 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
     end
 
     test "allows overriding the port number" do
-      assert %ServerState{port_number: 8080} =
-        build_server_state(port_number: 8080)
+      assert %ServerState{port_number: 8080} = build_server_state(port_number: 8080)
     end
 
     test "defaults to reading phantom_path from env" do
@@ -55,54 +54,57 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
 
   describe "external_command/1" do
     test "with no phantom_args" do
-      state = build_server_state(
-        phantom_path: "phantomjs",
-        port_number: 8000
-      )
+      state =
+        build_server_state(
+          phantom_path: "phantomjs",
+          port_number: 8000
+        )
 
       assert %ExternalCommand{
-        executable: "phantomjs",
-        args: [
-          "--webdriver=8000",
-          "--local-storage-path=#{ServerState.local_storage_path(state)}"
-        ]
-      } == ServerState.external_command(state)
+               executable: "phantomjs",
+               args: [
+                 "--webdriver=8000",
+                 "--local-storage-path=#{ServerState.local_storage_path(state)}"
+               ]
+             } == ServerState.external_command(state)
     end
 
     test "with phantom_args as a list" do
-      state = build_server_state(
-        phantom_path: "phantomjs",
-        port_number: 8000,
-        phantom_args: ["--debug"]
-      )
+      state =
+        build_server_state(
+          phantom_path: "phantomjs",
+          port_number: 8000,
+          phantom_args: ["--debug"]
+        )
 
       assert %ExternalCommand{
-        executable: "phantomjs",
-        args: [
-          "--webdriver=8000",
-          "--local-storage-path=#{ServerState.local_storage_path(state)}",
-          "--debug"
-        ]
-      } == ServerState.external_command(state)
+               executable: "phantomjs",
+               args: [
+                 "--webdriver=8000",
+                 "--local-storage-path=#{ServerState.local_storage_path(state)}",
+                 "--debug"
+               ]
+             } == ServerState.external_command(state)
     end
 
     test "with phantom_args as a string" do
-      state = build_server_state(
-        phantom_path: "phantomjs",
-        port_number: 8000,
-        local_storage_path: "/srv/wallaby",
-        phantom_args: "--debug --hello=world"
-      )
+      state =
+        build_server_state(
+          phantom_path: "phantomjs",
+          port_number: 8000,
+          local_storage_path: "/srv/wallaby",
+          phantom_args: "--debug --hello=world"
+        )
 
       assert %ExternalCommand{
-        executable: "phantomjs",
-        args: [
-          "--webdriver=8000",
-          "--local-storage-path=#{ServerState.local_storage_path(state)}",
-          "--debug",
-          "--hello=world",
-        ]
-      } == ServerState.external_command(state)
+               executable: "phantomjs",
+               args: [
+                 "--webdriver=8000",
+                 "--local-storage-path=#{ServerState.local_storage_path(state)}",
+                 "--debug",
+                 "--hello=world"
+               ]
+             } == ServerState.external_command(state)
     end
   end
 
@@ -111,7 +113,7 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
       state = ServerState.new("/tmp/wallaby")
 
       assert "/tmp/wallaby/local_storage" ==
-        ServerState.local_storage_path(state)
+               ServerState.local_storage_path(state)
     end
   end
 
@@ -120,7 +122,7 @@ defmodule Wallaby.Phantom.Server.ServerStateTest do
       state = ServerState.new("/tmp/wallaby")
 
       assert '/tmp/wallaby/wrapper' ==
-        ServerState.wrapper_script_path(state)
+               ServerState.wrapper_script_path(state)
     end
   end
 

--- a/test/wallaby/phantom/server_test.exs
+++ b/test/wallaby/phantom/server_test.exs
@@ -43,8 +43,7 @@ defmodule Wallaby.Phantom.ServerTest do
   test "does not start when the unable to start phantom" do
     Process.flag(:trap_exit, true)
 
-    assert {:error, {:crashed, _}} =
-      Server.start_link(phantom_path: "doesnotexist")
+    assert {:error, {:crashed, _}} = Server.start_link(phantom_path: "doesnotexist")
   end
 
   test "crashes when the wrapper script is killed" do
@@ -87,6 +86,7 @@ defmodule Wallaby.Phantom.ServerTest do
     case System.cmd("kill", ["-0", to_string(os_pid)], stderr_to_stdout: true) do
       {_, 0} ->
         true
+
       _ ->
         false
     end

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -8,14 +8,15 @@ defmodule Wallaby.Query.ErrorMessageTest do
     test "when the results are more then the expected count" do
       message =
         Query.css(".test", count: 1)
-        |> Map.put(:result, [1,2,3])
+        |> Map.put(:result, [1, 2, 3])
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, visible element that matched the css '.test' but 3, visible
-      elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, visible element that matched the css '.test' but 3, visible
+               elements were found.
+               """)
     end
 
     test "when the result is empty" do
@@ -25,10 +26,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, visible element that matched the css '.test' but 0, visible
-      elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, visible element that matched the css '.test' but 0, visible
+               elements were found.
+               """)
     end
 
     test "when the result is 1" do
@@ -38,10 +40,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 3, visible elements that matched the css '.test' but
-      only 1, visible element was found.
-      """
+      assert message ==
+               format("""
+               Expected to find 3, visible elements that matched the css '.test' but
+               only 1, visible element was found.
+               """)
     end
 
     test "when the result is less then the minimum result" do
@@ -51,36 +54,39 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find at least 3, visible elements that matched the css
-      '.test' but only 1, visible element was found.
-      """
+      assert message ==
+               format("""
+               Expected to find at least 3, visible elements that matched the css
+               '.test' but only 1, visible element was found.
+               """)
     end
 
     test "when the result is more then the maximum" do
       message =
         Query.css(".test", minimum: 3, maximum: 5)
-        |> Map.put(:result, [1,2,3,4,5,6])
+        |> Map.put(:result, [1, 2, 3, 4, 5, 6])
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find no more then 5, visible elements that matched the css
-      '.test' but 6, visible elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find no more then 5, visible elements that matched the css
+               '.test' but 6, visible elements were found.
+               """)
     end
 
     test "when the result is supposed to be invisible" do
       message =
         Query.css(".test", count: 1, visible: false)
-        |> Map.put(:result, [1,2,3])
+        |> Map.put(:result, [1, 2, 3])
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, invisible element that matched the css '.test' but 3,
-      invisible elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, invisible element that matched the css '.test' but 3,
+               invisible elements were found.
+               """)
     end
 
     test "when the minimum is set less then the maximum" do
@@ -98,10 +104,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, visible, selected element that matched the css '.test' but 0,
-      visible, selected elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, visible, selected element that matched the css '.test' but 0,
+               visible, selected elements were found.
+               """)
     end
 
     test "when the result is not supposed to be selected" do
@@ -110,10 +117,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, visible, unselected element that matched the css '.test' but 0,
-      visible, unselected elements were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, visible, unselected element that matched the css '.test' but 0,
+               visible, unselected elements were found.
+               """)
     end
 
     test "with text queries" do
@@ -121,17 +129,21 @@ defmodule Wallaby.Query.ErrorMessageTest do
         Query.text("test")
         |> ErrorMessage.message(:not_found)
         |> format
-      assert message == format """
-      Expected to find 1, visible element with the text 'test' but 0, visible elements with the text were found.
-      """
+
+      assert message ==
+               format("""
+               Expected to find 1, visible element with the text 'test' but 0, visible elements with the text were found.
+               """)
 
       message =
         Query.text("test", count: 2)
         |> ErrorMessage.message(:not_found)
         |> format
-      assert message == format """
-      Expected to find 2, visible elements with the text 'test' but 0, visible elements with the text were found.
-      """
+
+      assert message ==
+               format("""
+               Expected to find 2, visible elements with the text 'test' but 0, visible elements with the text were found.
+               """)
     end
 
     test "with value queries" do
@@ -139,9 +151,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         Query.value("test")
         |> ErrorMessage.message(:not_found)
         |> format
-      assert message == format """
-      Expected to find 1, visible element with the attribute 'value' with value 'test' but 0, visible elements with the attribute were found.
-      """
+
+      assert message ==
+               format("""
+               Expected to find 1, visible element with the attribute 'value' with value 'test' but 0, visible elements with the attribute were found.
+               """)
     end
 
     test "with attribute key, value pair queries" do
@@ -149,9 +163,11 @@ defmodule Wallaby.Query.ErrorMessageTest do
         Query.attribute("an-attribute", "an-attribute-value")
         |> ErrorMessage.message(:not_found)
         |> format
-      assert message == format """
-      Expected to find 1, visible element with the attribute 'an-attribute' with value 'an-attribute-value' but 0, visible elements with the attribute were found.
-      """
+
+      assert message ==
+               format("""
+               Expected to find 1, visible element with the attribute 'an-attribute' with value 'an-attribute-value' but 0, visible elements with the attribute were found.
+               """)
     end
 
     test "with data attribute queries" do
@@ -160,9 +176,10 @@ defmodule Wallaby.Query.ErrorMessageTest do
         |> ErrorMessage.message(:not_found)
         |> format
 
-      assert message == format """
-      Expected to find 1, visible element with the attribute 'data-role' with value 'data-attribute-value' but 0, visible elements with the attribute were found.
-      """
+      assert message ==
+               format("""
+               Expected to find 1, visible element with the attribute 'data-role' with value 'data-attribute-value' but 0, visible elements with the attribute were found.
+               """)
     end
   end
 

--- a/test/wallaby/query_test.exs
+++ b/test/wallaby/query_test.exs
@@ -71,6 +71,7 @@ defmodule Wallaby.QueryTest do
         conditions: [minimum: 1, maximum: 3],
         result: [%{}, %{}]
       }
+
       assert Query.matches_count?(query, 2)
 
       query = %Query{conditions: [minimum: 1, maximum: 1], result: [%{}]}


### PR DESCRIPTION
### What
This runs `mix format` across the codebase and adds a check to `.travis.yml` to ensure all new commits are formatted as well.

### Why
I think it's a lot more common than when #356 was open to have editors auto format on save. Since the codebase isn't formatted, when I make changes to a file my diff ends up becoming the few lines I've changed plus formatting changes for the rest of the file. I think if take the leap and format the entire codebase, we'll be able to have smaller, more meaningful diffs for future PRs.

### Other considerations

I know this will create merge conflicts with our other open PRs. I'd be happy to exclude whatever files we need from this. Or possibly we could run the formatter the files changed in open PRs, squash the PR down to 1 commit, and then rebase on master if we decide to merge this first. If there's a better way, I'm totally open to suggestions. I'm just looking for a way I can stop having to look at my diffs and separate my changes from the formatter's changes.
