### PR TITLE
Increase timeout for starting phantomjs servers

### DIFF
--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -105,7 +105,7 @@ defmodule Wallaby.Phantom.Server do
   @spec start_phantom(ServerState.t()) ::
           {:ok, ServerState.t()} | {:error, StartTask.error_reason()}
   defp start_phantom(%ServerState{} = state) do
-    state |> StartTask.async() |> Task.await()
+    state |> StartTask.async() |> Task.await(10_000)
   end
 
   @spec wait_for_stop(os_pid) :: nil


### PR DESCRIPTION
Since we've migrated to Github actions, I've been getting intermittent test run failures saying there was a timeout starting the phantomjs servers

    06:11:00.723 [info]  Application wallaby exited: Wallaby.start(:normal, []) returned an error: shutdown: failed to start child: Wallaby.Phantom
      ** (EXIT) shutdown: failed to start child: Wallaby.ServerPool
        ** (EXIT) an exception was raised:
          ** (MatchError) no match of right hand side value: {:error, {:timeout, {Task, :await, [%Task{owner: #PID<0.2485.0>, pid: #PID<0.2487.0>, ref: #Reference<0.1308822412.2435317761.47248>}, 5000]}}}
            (poolboy) src/poolboy.erl:275: :poolboy.new_worker/1
            (poolboy) src/poolboy.erl:296: :poolboy.prepopulate/3
            (poolboy) src/poolboy.erl:145: :poolboy.init/3
            (stdlib) gen_server.erl:374: :gen_server.init_it/2
            (stdlib) gen_server.erl:342: :gen_server.init_it/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3

https://github.com/aaronrenner/wallaby/runs/318771900

I am thinking this is due to hardware differences between Github Actions and TravisCI (since it starts the number of workers equal to the number of schedulers online). I'm not quite sure of why the servers are taking longer to start (maybe increased load on the system), but since PhantomJS support is going away, bumping the timeout from 5 seconds to 10 seconds seems like a good temporary fix.