### PR TITLE
Add typespec for Phantom.Driver.find_elements/2

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -1,6 +1,8 @@
 defmodule Wallaby.HTTPClient do
   @moduledoc false
 
+  alias Wallaby.Query
+
   @type method :: :post | :get | :delete
   @type url :: String.t()
   @type params :: map | String.t()
@@ -131,6 +133,7 @@ defmodule Wallaby.HTTPClient do
     [{"Accept", "application/json"}, {"Content-Type", "application/json"}]
   end
 
+  @spec to_params(Query.compiled()) :: map
   def to_params({:xpath, xpath}) do
     %{using: "xpath", value: xpath}
   end

--- a/lib/wallaby/phantom/driver.ex
+++ b/lib/wallaby/phantom/driver.ex
@@ -10,6 +10,7 @@ defmodule Wallaby.Phantom.Driver do
   alias Wallaby.Phantom
   alias Wallaby.Phantom.Server
   alias Wallaby.Metadata
+  alias Wallaby.Query
   alias Wallaby.Session
   alias Wallaby.StaleReferenceError
 
@@ -74,8 +75,7 @@ defmodule Wallaby.Phantom.Driver do
   Finds an element on the page for a session. If an element is provided then
   the query will be scoped to within that element.
   """
-  # @spec find_elements(Locator.t, query) :: t
-
+  @spec find_elements(Session.t() | Element.t(), Query.compiled()) :: {:ok, [Element.t()]}
   def find_elements(parent, locator) do
     check_logs!(parent, fn ->
       with {:ok, resp} <- request(:post, parent.url <> "/elements", to_params(locator)),


### PR DESCRIPTION
I wasn't sure the type of the `locator` param on this function, so I tracked it down and added a typespec. This matches the typespec in `Wallaby.Experimental.Selenium.WebdriverClient`:

https://github.com/elixir-wallaby/wallaby/blob/486e758d77c502884df949eee007aa085d848fad/lib/wallaby/experimental/selenium/webdriver_client.ex#L37-L47

I didn't end up adding the `{:error, _}` return because I'm still tracking down the possible error returns for these functions, and we haven't documented the error returns anywhere else in our API clients. I'm thinking I'd like to figure that out and submit that in a future PR.