### PR TITLE
Format integration tests

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,integration_test,test}/**/*.{ex,exs}"]
 ]

--- a/integration_test/cases/browser/all_test.exs
+++ b/integration_test/cases/browser/all_test.exs
@@ -10,8 +10,8 @@ defmodule Wallaby.Integration.Browser.AllTest do
 
     test "returns all of the elements matching the query", %{page: page} do
       assert page
-      |> all(Query.css("li"))
-      |> Enum.count == 3
+             |> all(Query.css("li"))
+             |> Enum.count() == 3
     end
   end
 end

--- a/integration_test/cases/browser/assert_css_test.exs
+++ b/integration_test/cases/browser/assert_css_test.exs
@@ -19,7 +19,7 @@ defmodule Wallaby.Integration.Browser.AssertCssTest do
 
   test "has_no_css/2 raises error if the css is found", %{session: session} do
     refute session
-    |> visit("nesting.html")
-    |> has_no_css?(".user")
+           |> visit("nesting.html")
+           |> has_no_css?(".user")
   end
 end

--- a/integration_test/cases/browser/assert_refute_has_test.exs
+++ b/integration_test/cases/browser/assert_refute_has_test.exs
@@ -8,9 +8,10 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
   @wrong_exact_found_query Query.css(".user", count: 5)
   describe "assert_has/2" do
     test "passes if the query is present on the page", %{session: session} do
-      return = session
-               |> visit("nesting.html")
-               |> assert_has(@found_query)
+      return =
+        session
+        |> visit("nesting.html")
+        |> assert_has(@found_query)
 
       assert %Wallaby.Session{} = return
     end
@@ -34,9 +35,10 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
 
   describe "refute_has/2" do
     test "passes if the query is not found on the page", %{session: session} do
-      return = session
-               |> visit("nesting.html")
-               |> refute_has(@not_found_query)
+      return =
+        session
+        |> visit("nesting.html")
+        |> refute_has(@not_found_query)
 
       assert %Wallaby.Session{} = return
     end

--- a/integration_test/cases/browser/assert_text_test.exs
+++ b/integration_test/cases/browser/assert_text_test.exs
@@ -5,7 +5,7 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
 
   test "has_text?/2 waits for presence of text and returns a bool", %{session: session} do
     element =
-    session
+      session
       |> visit("wait.html")
       |> find(Query.css("#container"))
 
@@ -13,9 +13,11 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
     refute has_text?(element, "rain")
   end
 
-  test "assert_text/2 waits for presence of text and and returns true if found", %{session: session} do
+  test "assert_text/2 waits for presence of text and and returns true if found", %{
+    session: session
+  } do
     element =
-    session
+      session
       |> visit("wait.html")
       |> find(Query.css("#container"))
 
@@ -24,7 +26,7 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
 
   test "assert_text/2 will raise an exception for text not found", %{session: session} do
     element =
-    session
+      session
       |> visit("wait.html")
       |> find(Query.css("#container"))
 

--- a/integration_test/cases/browser/button_down_test.exs
+++ b/integration_test/cases/browser/button_down_test.exs
@@ -22,14 +22,14 @@ defmodule Wallaby.Integration.Browser.ButtonDownTest do
 
   defp button_down_test(page, button, expected_log_prefix) do
     refute page
-             |> visible?(Query.text("#{expected_log_prefix} Down"))
+           |> visible?(Query.text("#{expected_log_prefix} Down"))
 
-      assert page
-             |> hover(Query.text("Button 1"))
-             |> button_down(button)
-             |> visible?(Query.text("#{expected_log_prefix} Down"))
+    assert page
+           |> hover(Query.text("Button 1"))
+           |> button_down(button)
+           |> visible?(Query.text("#{expected_log_prefix} Down"))
 
-      refute page
-             |> visible?(Query.text("#{expected_log_prefix} Up"))
+    refute page
+           |> visible?(Query.text("#{expected_log_prefix} Up"))
   end
 end

--- a/integration_test/cases/browser/button_up_test.exs
+++ b/integration_test/cases/browser/button_up_test.exs
@@ -36,30 +36,30 @@ defmodule Wallaby.Integration.Browser.ButtonUpTest do
 
   defp button_up_test(page, button, expected_log_prefix) do
     refute page
-             |> visible?(Query.text("#{expected_log_prefix} Up"))
+           |> visible?(Query.text("#{expected_log_prefix} Up"))
 
-      assert page
-             |> hover(Query.text("Button 1"))
-             |> button_down(button)
-             |> button_up(button)
-             |> visible?(Query.text("#{expected_log_prefix} Up"))
+    assert page
+           |> hover(Query.text("Button 1"))
+           |> button_down(button)
+           |> button_up(button)
+           |> visible?(Query.text("#{expected_log_prefix} Up"))
 
-      refute page
-             |> visible?(Query.text("#{expected_log_prefix} Down"))
+    refute page
+           |> visible?(Query.text("#{expected_log_prefix} Down"))
   end
 
   defp move_cursor_then_button_up_test(page, button, expected_log_prefix) do
     refute page
-             |> visible?(Query.text("#{expected_log_prefix} Up"))
+           |> visible?(Query.text("#{expected_log_prefix} Up"))
 
-      assert page
-             |> hover(Query.text("Button 1"))
-             |> button_down(button)
-             |> hover(Query.text("Button 2"))
-             |> button_up(button)
-             |> visible?(Query.text("#{expected_log_prefix} Up"))
+    assert page
+           |> hover(Query.text("Button 1"))
+           |> button_down(button)
+           |> hover(Query.text("Button 2"))
+           |> button_up(button)
+           |> visible?(Query.text("#{expected_log_prefix} Up"))
 
-      refute page
-             |> visible?(Query.text("#{expected_log_prefix} Down"))
+    refute page
+           |> visible?(Query.text("#{expected_log_prefix} Down"))
   end
 end

--- a/integration_test/cases/browser/clear_test.exs
+++ b/integration_test/cases/browser/clear_test.exs
@@ -23,9 +23,9 @@ defmodule Wallaby.Integration.Browser.ClearTest do
 
     test "works with queries", %{page: page} do
       assert page
-      |> fill_in(Query.text_field("name_field"), with: "test")
-      |> clear(Query.text_field("name_field"))
-      |> text(Query.text_field("name_field")) == ""
+             |> fill_in(Query.text_field("name_field"), with: "test")
+             |> clear(Query.text_field("name_field"))
+             |> text(Query.text_field("name_field")) == ""
     end
   end
 end

--- a/integration_test/cases/browser/click_button_test.exs
+++ b/integration_test/cases/browser/click_button_test.exs
@@ -16,7 +16,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("button with no type"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -26,7 +26,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("button-no-type"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -36,7 +36,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("button-no-type-id"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -46,7 +46,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("Submit button"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -56,7 +56,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("button-submit"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -66,7 +66,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("button-submit-id"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -98,7 +98,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     page
     |> fill_in(Query.text_field("name_field"), with: "Erlich Bachman")
 
-    assert find(page, css("#name_field"))  |> has_value?("Erlich Bachman")
+    assert find(page, css("#name_field")) |> has_value?("Erlich Bachman")
 
     click(page, button("button-button-id"))
 
@@ -142,7 +142,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("Submit input"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -152,7 +152,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("input-submit"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -162,7 +162,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("input-submit-id"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -238,7 +238,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("input-image"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -248,7 +248,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
     current_url =
       page
       |> click(button("input-image-id"))
-      |> IndexPage.ensure_page_loaded
+      |> IndexPage.ensure_page_loaded()
       |> current_url
 
     assert current_url =~ "http://localhost:#{URI.parse(current_url).port}/index.html"
@@ -290,7 +290,7 @@ defmodule Wallaby.Integration.Browser.Actions.ClickButtonTest do
 
   test "works with elements", %{page: page} do
     assert page
-    |> find(button("I'm a button"))
-    |> Element.click()
+           |> find(button("I'm a button"))
+           |> Element.click()
   end
 end

--- a/integration_test/cases/browser/cookies_test.exs
+++ b/integration_test/cases/browser/cookies_test.exs
@@ -8,7 +8,7 @@ defmodule Wallaby.Integration.Browser.CookiesTest do
       list =
         session
         |> visit("/")
-        |> Browser.cookies
+        |> Browser.cookies()
 
       assert list == []
     end
@@ -21,7 +21,7 @@ defmodule Wallaby.Integration.Browser.CookiesTest do
         |> visit("/")
         |> Browser.set_cookie("api_token", "abc123")
         |> visit("/")
-        |> Browser.cookies
+        |> Browser.cookies()
         |> hd()
 
       assert cookie["name"] == "api_token"

--- a/integration_test/cases/browser/current_path_test.exs
+++ b/integration_test/cases/browser/current_path_test.exs
@@ -3,7 +3,7 @@ defmodule Wallaby.Integration.Browser.CurrentPathTest do
 
   alias Wallaby.Integration.Pages.{IndexPage, Page1}
 
-  test "gets the current_url of the session", %{session: session}  do
+  test "gets the current_url of the session", %{session: session} do
     url =
       session
       |> IndexPage.visit()
@@ -14,7 +14,7 @@ defmodule Wallaby.Integration.Browser.CurrentPathTest do
     assert url == "http://localhost:#{URI.parse(url).port}/page_1.html"
   end
 
-  test "gets the current_path of the session", %{session: session}  do
+  test "gets the current_path of the session", %{session: session} do
     path =
       session
       |> IndexPage.visit()

--- a/integration_test/cases/browser/dialog_test.exs
+++ b/integration_test/cases/browser/dialog_test.exs
@@ -8,13 +8,16 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "accept_alert/2" do
     test "accept window.alert and get message", %{page: page} do
-      message = accept_alert page, fn(p) ->
-        click(p, Query.link("Alert"))
-      end
+      message =
+        accept_alert(page, fn p ->
+          click(p, Query.link("Alert"))
+        end)
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "This is an alert!"
       assert result == "Alert accepted"
     end
@@ -22,13 +25,16 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "accept_confirm/2" do
     test "accept window.confirm and get message", %{page: page} do
-      message = accept_confirm page, fn(p) ->
-        click(p, Query.link("Confirm"))
-      end
+      message =
+        accept_confirm(page, fn p ->
+          click(p, Query.link("Confirm"))
+        end)
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "Are you sure?"
       assert result == "Confirm returned true"
     end
@@ -36,13 +42,16 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "dismiss_confirm/2" do
     test "dismiss window.confirm and get message", %{page: page} do
-      message = dismiss_confirm page, fn(p) ->
-        click(p, Query.link("Confirm"))
-      end
+      message =
+        dismiss_confirm(page, fn p ->
+          click(p, Query.link("Confirm"))
+        end)
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "Are you sure?"
       assert result == "Confirm returned false"
     end
@@ -50,41 +59,47 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "accept_prompt/2" do
     test "accept window.prompt with default value and get message", %{page: page} do
-      message = accept_prompt page, fn(p) ->
-        click(p, Query.link("Prompt"))
-      end
+      message =
+        accept_prompt(page, fn p ->
+          click(p, Query.link("Prompt"))
+        end)
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "What's your name?"
       assert result == "Prompt returned default"
     end
 
     test "ensure the input value is a string", %{page: page} do
       assert_raise FunctionClauseError, fn ->
-        accept_prompt(page, [with: nil], fn(_) -> :noop end)
+        accept_prompt(page, [with: nil], fn _ -> :noop end)
       end
 
       assert_raise FunctionClauseError, fn ->
-        accept_prompt(page, [with: 123], fn(_) -> :noop end)
+        accept_prompt(page, [with: 123], fn _ -> :noop end)
       end
 
       assert_raise FunctionClauseError, fn ->
-        accept_prompt(page, [with: :foo], fn(_) -> :noop end)
+        accept_prompt(page, [with: :foo], fn _ -> :noop end)
       end
     end
   end
 
   describe "accept_prompt/3" do
     test "accept window.prompt with value and get message", %{page: page} do
-      message = accept_prompt page, [with: "Wallaby"], fn(p) ->
-        click(p, Query.link("Prompt"))
-      end
+      message =
+        accept_prompt(page, [with: "Wallaby"], fn p ->
+          click(p, Query.link("Prompt"))
+        end)
+
       result =
         page
         |> find(Query.css("#result"))
         |> Element.text()
+
       assert message == "What's your name?"
       assert result == "Prompt returned Wallaby"
     end
@@ -92,9 +107,10 @@ defmodule Wallaby.Integration.Browser.DialogTest do
 
   describe "dismiss_prompt/2" do
     test "dismiss window.prompt and get message", %{page: page} do
-      message = dismiss_prompt page, fn(p) ->
-        click(p, Query.link("Prompt"))
-      end
+      message =
+        dismiss_prompt(page, fn p ->
+          click(p, Query.link("Prompt"))
+        end)
 
       result =
         page

--- a/integration_test/cases/browser/execute_script_test.exs
+++ b/integration_test/cases/browser/execute_script_test.exs
@@ -10,90 +10,111 @@ defmodule Wallaby.Integration.Browser.ExecuteScriptTest do
     return arguments[1]
   """
   test "executing scripts with arguments and returning", %{session: session} do
-
     assert session
-      |> visit("page_1.html")
-      |> execute_script(@script, ["now you see me", "return value"])
-      |> find(Query.css("#new-element"))
-      |> Element.text == "now you see me"
+           |> visit("page_1.html")
+           |> execute_script(@script, ["now you see me", "return value"])
+           |> find(Query.css("#new-element"))
+           |> Element.text() == "now you see me"
   end
 
   test "executing scripts with arguments and callback returns session", %{session: session} do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script(@script, ["now you see me", "return value"], fn(value) ->
-           assert value == "return value"
-           send self(), {:callback, value}
-         end)
+      |> execute_script(@script, ["now you see me", "return value"], fn value ->
+        assert value == "return value"
+        send(self(), {:callback, value})
+      end)
 
     assert result == session
 
-    assert_received{:callback, "return value"}
+    assert_received {:callback, "return value"}
 
     assert session
-    |> find(Query.css("#new-element"))
-    |> Element.text == "now you see me"
+           |> find(Query.css("#new-element"))
+           |> Element.text() == "now you see me"
   end
 
   test "executing asynchronous script and callback returns session", %{session: session} do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script_async("arguments[arguments.length - 1]('hello')", [], fn(value) ->
-           assert value == "hello"
-           send self(), {:callback, value}
-         end)
+      |> execute_script_async("arguments[arguments.length - 1]('hello')", [], fn value ->
+        assert value == "hello"
+        send(self(), {:callback, value})
+      end)
+
     assert result == session
-    assert_received{:callback, "hello"}
+    assert_received {:callback, "hello"}
   end
 
-  test "executing asynchronous script with arguments and callback returns session", %{session: session} do
+  test "executing asynchronous script with arguments and callback returns session", %{
+    session: session
+  } do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script_async("arguments[arguments.length - 1](arguments[0]);", ["hello"], fn(value) ->
-           assert value == "hello"
-           send self(), {:callback, value}
-         end)
+      |> execute_script_async(
+        "arguments[arguments.length - 1](arguments[0]);",
+        ["hello"],
+        fn value ->
+          assert value == "hello"
+          send(self(), {:callback, value})
+        end
+      )
+
     assert result == session
-    assert_received{:callback, "hello"}
+    assert_received {:callback, "hello"}
   end
 
   test "returning element after asynchronous operation with timeout", %{session: session} do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script_async("var callback = arguments[0]; setTimeout(function() { callback(document.getElementById('visible').innerHTML) }, 300);", [], fn(value) ->
-           assert value == "Visible"
-           send self(), {:callback, value}
-         end)
+      |> execute_script_async(
+        "var callback = arguments[0]; setTimeout(function() { callback(document.getElementById('visible').innerHTML) }, 300);",
+        [],
+        fn value ->
+          assert value == "Visible"
+          send(self(), {:callback, value})
+        end
+      )
+
     assert result == session
-    assert_received{:callback, "Visible"}
+    assert_received {:callback, "Visible"}
   end
 
   test "returning element after asynchronous operation", %{session: session} do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script_async("var callback = arguments[0]; callback(document.getElementById('visible').innerHTML);", [], fn(value) ->
-           assert value == "Visible"
-           send self(), {:callback, value}
-         end)
+      |> execute_script_async(
+        "var callback = arguments[0]; callback(document.getElementById('visible').innerHTML);",
+        [],
+        fn value ->
+          assert value == "Visible"
+          send(self(), {:callback, value})
+        end
+      )
+
     assert result == session
-    assert_received{:callback, "Visible"}
+    assert_received {:callback, "Visible"}
   end
 
   test "returning element after asynchronous operation with arguments", %{session: session} do
     result =
       session
       |> visit("page_1.html")
-      |> execute_script_async("arguments[arguments.length - 1](document.getElementById(arguments[0]).innerHTML);", ["visible"], fn(value) ->
-           assert value == "Visible"
-           send self(), {:callback, value}
-         end)
-    assert result == session
-    assert_received{:callback, "Visible"}
-  end
+      |> execute_script_async(
+        "arguments[arguments.length - 1](document.getElementById(arguments[0]).innerHTML);",
+        ["visible"],
+        fn value ->
+          assert value == "Visible"
+          send(self(), {:callback, value})
+        end
+      )
 
+    assert result == session
+    assert_received {:callback, "Visible"}
+  end
 end

--- a/integration_test/cases/browser/file_test.exs
+++ b/integration_test/cases/browser/file_test.exs
@@ -16,7 +16,7 @@ defmodule Wallaby.Integration.Browser.FileTest do
       page
       |> attach_file(file_field("file_input"), path: "integration_test/support/fixtures/file.txt")
 
-      find(page, css("#file_field"), fn (element) ->
+      find(page, css("#file_field"), fn element ->
         assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
       end)
     end
@@ -25,7 +25,7 @@ defmodule Wallaby.Integration.Browser.FileTest do
       page
       |> attach_file(file_field("file_field"), path: "integration_test/support/fixtures/file.txt")
 
-      find(page, css("#file_field"), fn (element) ->
+      find(page, css("#file_field"), fn element ->
         assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
       end)
     end
@@ -34,7 +34,7 @@ defmodule Wallaby.Integration.Browser.FileTest do
       page
       |> attach_file(file_field("File"), path: "integration_test/support/fixtures/file.txt")
 
-      find(page, css("#file_field"), fn (element) ->
+      find(page, css("#file_field"), fn element ->
         assert Wallaby.Element.value(element) == "C:\\fakepath\\file.txt"
       end)
     end
@@ -44,18 +44,22 @@ defmodule Wallaby.Integration.Browser.FileTest do
     page
     |> attach_file(file_field("File"), path: "integration_test/support/fixtures/fool.txt")
 
-    find(page, css("#file_field"), fn (element) ->
+    find(page, css("#file_field"), fn element ->
       assert Wallaby.Element.value(element) == ""
     end)
   end
 
   test "checks for labels without for attributes", %{page: page} do
     assert_raise Wallaby.QueryError, ~r/label has no 'for'/, fn ->
-      attach_file(page, file_field("File field with bad label"), path: "integration_test/support/fixtures/file.txt")
+      attach_file(page, file_field("File field with bad label"),
+        path: "integration_test/support/fixtures/file.txt"
+      )
     end
   end
 
   test "escapes quotes", %{page: page} do
-    assert attach_file(page, file_field("I'm a file field"), path: "integration_test/support/fixtures/file.txt")
+    assert attach_file(page, file_field("I'm a file field"),
+             path: "integration_test/support/fixtures/file.txt"
+           )
   end
 end

--- a/integration_test/cases/browser/fill_in_test.exs
+++ b/integration_test/cases/browser/fill_in_test.exs
@@ -14,8 +14,8 @@ defmodule Wallaby.Integration.Browser.FillInTest do
     |> fill_in(Query.text_field("name"), with: "Chris")
 
     assert page
-    |> find(Query.text_field("name"))
-    |> has_value?("Chris")
+           |> find(Query.text_field("name"))
+           |> has_value?("Chris")
   end
 
   test "filling in input by id", %{page: page} do
@@ -40,6 +40,7 @@ defmodule Wallaby.Integration.Browser.FillInTest do
     assert page
            |> find(Query.css("#name_field"))
            |> has_value?("Alex")
+
     assert page
            |> find(Query.css("#email_field"))
            |> has_value?("alex@example.com")

--- a/integration_test/cases/browser/find_test.exs
+++ b/integration_test/cases/browser/find_test.exs
@@ -37,7 +37,7 @@ defmodule Wallaby.Integration.Browser.FindTest do
         |> all(css(".user"))
 
       assert Enum.count(users) == 3
-      assert List.first(users) |> Element.text == "Chris"
+      assert List.first(users) |> Element.text() == "Chris"
     end
 
     test "throws a not found error if the element could not be found", %{page: page} do
@@ -48,13 +48,13 @@ defmodule Wallaby.Integration.Browser.FindTest do
 
     test "throws a not found error if the xpath could not be found", %{page: page} do
       assert_raise Wallaby.QueryError, ~r/Expected (.*) xpath '\/\/test-element'/, fn ->
-        find page, Query.xpath("//test-element")
+        find(page, Query.xpath("//test-element"))
       end
     end
 
     test "ambiguous queries raise an exception", %{page: page} do
       assert_raise Wallaby.QueryError, ~r/Expected (.*) 1(.*) but 5/, fn ->
-        find page, Query.css(".user")
+        find(page, Query.css(".user"))
       end
     end
 
@@ -73,7 +73,7 @@ defmodule Wallaby.Integration.Browser.FindTest do
       end
 
       assert find(session, Query.css("#visible", count: :any))
-      |> length == 1
+             |> length == 1
     end
 
     test "finds invisible elements", %{page: page} do
@@ -103,18 +103,18 @@ defmodule Wallaby.Integration.Browser.FindTest do
 
     test "returns the element as the argument to the callback", %{page: page} do
       page
-      |> find(Query.css("h1"), & assert has_text?(&1, "Page 1") )
+      |> find(Query.css("h1"), &assert(has_text?(&1, "Page 1")))
     end
 
     test "returns the parent", %{page: page} do
       assert page
-      |> find(Query.css("h1"), fn(_) -> nil end) == page
+             |> find(Query.css("h1"), fn _ -> nil end) == page
     end
 
     test "returns all the elements found with the query", %{page: page} do
-      assert find page, Query.css(".user", count: 5), fn(elements) ->
-         assert Enum.count(elements) == 5
-      end
+      assert find(page, Query.css(".user", count: 5), fn elements ->
+               assert Enum.count(elements) == 5
+             end)
     end
   end
 

--- a/integration_test/cases/browser/frames_test.exs
+++ b/integration_test/cases/browser/frames_test.exs
@@ -20,5 +20,5 @@ defmodule Wallaby.Integration.Browser.FramesTest do
     |> assert_has(Query.css("h1", text: "Frames Page"))
     |> assert_has(Query.css("h1", text: "Page 1", count: 0))
     |> assert_has(Query.css("h1", text: "Page 2", count: 0))
-   end
+  end
 end

--- a/integration_test/cases/browser/has_css_test.exs
+++ b/integration_test/cases/browser/has_css_test.exs
@@ -9,14 +9,14 @@ defmodule Wallaby.Integration.Browser.HasCssTest do
   describe "has_css/2" do
     test "checks if the query has the specified text", %{page: page} do
       assert page
-      |> has_css?(".user")
+             |> has_css?(".user")
     end
   end
 
   describe "has_no_css/2" do
     test "checks that there is no visible matching css", %{page: page} do
       assert page
-      |> has_no_css?("#invisible")
+             |> has_no_css?("#invisible")
     end
   end
 end

--- a/integration_test/cases/browser/has_text_test.exs
+++ b/integration_test/cases/browser/has_text_test.exs
@@ -11,32 +11,32 @@ defmodule Wallaby.Integration.Browser.HasTextTest do
   describe "has_text/3" do
     test "checks if the query has the specified text", %{page: page} do
       assert page
-      |> has_text?(@h1, "Page 1")
+             |> has_text?(@h1, "Page 1")
     end
   end
 
   describe "has_text/2" do
     test "checks if the element has the specified text", %{page: page} do
       assert page
-      |> find(@h1)
-      |> has_text?("Page 1")
+             |> find(@h1)
+             |> has_text?("Page 1")
     end
 
     test "matches all text under the element", %{page: page} do
       assert page
-      |> find(Query.css(".lots-of-text"))
-      |> has_text?("Text 2")
+             |> find(Query.css(".lots-of-text"))
+             |> has_text?("Text 2")
     end
 
     test "works with sessions", %{page: page} do
       assert page
-      |> has_text?("Page 1")
+             |> has_text?("Page 1")
     end
 
     test "retries the query", %{page: page} do
       assert page
-      |> visit("wait.html")
-      |> has_text?("orange") == true
+             |> visit("wait.html")
+             |> has_text?("orange") == true
     end
   end
 end

--- a/integration_test/cases/browser/has_value_test.exs
+++ b/integration_test/cases/browser/has_value_test.exs
@@ -12,17 +12,17 @@ defmodule Wallaby.Integration.Browser.HasValueTest do
   describe "has_value?/3" do
     test "checks to see if query has a specific value", %{page: page} do
       assert page
-      |> fill_in(@name_field, with: "Chris")
-      |> has_value?(@name_field, "Chris")
+             |> fill_in(@name_field, with: "Chris")
+             |> has_value?(@name_field, "Chris")
     end
   end
 
   describe "has_value?/2" do
     test "checks that the elements value matches the specified value", %{page: page} do
       assert page
-      |> fill_in(@name_field, with: "Chris")
-      |> find(@name_field)
-      |> has_value?("Chris")
+             |> fill_in(@name_field, with: "Chris")
+             |> find(@name_field)
+             |> has_value?("Chris")
     end
   end
 end

--- a/integration_test/cases/browser/js_errors_test.exs
+++ b/integration_test/cases/browser/js_errors_test.exs
@@ -17,6 +17,7 @@ defmodule Wallaby.Integration.Phantom.JSErrorsTest do
       session
       |> visit("/logs.html")
     end
+
     assert capture_io(fun) == "Capture console logs\n"
   end
 

--- a/integration_test/cases/browser/local_storage_test.exs
+++ b/integration_test/cases/browser/local_storage_test.exs
@@ -10,28 +10,28 @@ defmodule Wallaby.Integration.Browser.LocalStorageTest do
   @tag :skip_test_session
   test "local storage is not shared between sessions" do
     # Checkout all sessions
-    {:ok, session}  = start_test_session()
-    {:ok, s2}       = start_test_session()
-    {:ok, s3}       = start_test_session()
+    {:ok, session} = start_test_session()
+    {:ok, s2} = start_test_session()
+    {:ok, s3} = start_test_session()
 
     session
     |> visit("index.html")
     |> execute_script(@set_value_script)
 
     session
-    |> execute_script(@get_value_script, fn(value) -> send self(), {:result, value} end)
+    |> execute_script(@get_value_script, fn value -> send(self(), {:result, value}) end)
 
     assert_received {:result, "foo"}
 
     s2
     |> visit("index.html")
-    |> execute_script(@get_value_script, fn(value) -> send self(), {:callback, value} end)
+    |> execute_script(@get_value_script, fn value -> send(self(), {:callback, value}) end)
 
     assert_received {:callback, nil}
 
     s3
     |> visit("index.html")
-    |> execute_script(@get_value_script, fn(value) -> send self(), {:callback2, value} end)
+    |> execute_script(@get_value_script, fn value -> send(self(), {:callback2, value}) end)
 
     assert_received {:callback2, nil}
 
@@ -42,7 +42,7 @@ defmodule Wallaby.Integration.Browser.LocalStorageTest do
 
     new_session
     |> visit("index.html")
-    |> execute_script(@get_value_script, fn(value) -> send self(), {:callback3, value} end)
+    |> execute_script(@get_value_script, fn value -> send(self(), {:callback3, value}) end)
 
     assert_received {:callback3, nil}
   end

--- a/integration_test/cases/browser/page_source_test.exs
+++ b/integration_test/cases/browser/page_source_test.exs
@@ -11,7 +11,7 @@ defmodule Wallaby.Integration.Browser.PageSourceTest do
     actual_html =
       "integration_test/support/pages/index.html"
       |> Path.absname()
-      |> File.read!
+      |> File.read!()
       |> clean_up_html
 
     # Firefox inserts a <!doctype html> so you can't do an exact comparison
@@ -21,6 +21,6 @@ defmodule Wallaby.Integration.Browser.PageSourceTest do
   def clean_up_html(string) do
     string
     |> String.replace(~r/\s+/, "")
-    |> String.downcase
+    |> String.downcase()
   end
 end

--- a/integration_test/cases/browser/screenshot_test.exs
+++ b/integration_test/cases/browser/screenshot_test.exs
@@ -31,11 +31,11 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     assert Enum.count(element_screenshots) == 1
     assert Enum.count(parent_screenshots) == 1
 
-    Enum.each(element_screenshots ++ parent_screenshots, fn(path) ->
-      assert File.exists? path
+    Enum.each(element_screenshots ++ parent_screenshots, fn path ->
+      assert File.exists?(path)
     end)
 
-    File.rm_rf! "#{File.cwd!}/screenshots"
+    File.rm_rf!("#{File.cwd!()}/screenshots")
   end
 
   test "users can specify the screenshot directory", %{page: page} do
@@ -46,15 +46,15 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
       |> take_screenshot
       |> Map.get(:screenshots)
 
-    assert screenshots |> Enum.count == 1
+    assert screenshots |> Enum.count() == 1
 
-    Enum.each screenshots, fn(path) ->
+    Enum.each(screenshots, fn path ->
       assert path =~ ~r/^shots\/(.*)$/
-      assert File.exists? path
-    end
+      assert File.exists?(path)
+    end)
 
     Application.put_env(:wallaby, :screenshot_dir, nil)
-    File.rm_rf! "#{File.cwd!}/shots"
+    File.rm_rf!("#{File.cwd!()}/shots")
   end
 
   test "users can specify the screenshot name", %{page: page} do
@@ -68,28 +68,31 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     assert screenshot_path == "shots/some_page.png"
 
     Application.put_env(:wallaby, :screenshot_dir, nil)
-    File.rm_rf! "#{File.cwd!}/shots"
+    File.rm_rf!("#{File.cwd!()}/shots")
   end
 
   test "automatically taking screenshots on failure", %{page: page} do
     assert_raise Wallaby.QueryError, fn ->
       find(page, css(".some-selector"))
     end
-    refute File.exists?("#{File.cwd!}/screenshots")
+
+    refute File.exists?("#{File.cwd!()}/screenshots")
 
     Application.put_env(:wallaby, :screenshot_on_failure, true)
 
-    output = capture_io( fn ->
-      assert_raise Wallaby.QueryError, fn ->
-        find(page, css(".some-selector"))
-      end
-    end)
+    output =
+      capture_io(fn ->
+        assert_raise Wallaby.QueryError, fn ->
+          find(page, css(".some-selector"))
+        end
+      end)
+
     assert Regex.match?(~r/Screenshot taken/, output)
 
-    assert File.exists?("#{File.cwd!}/screenshots")
-    assert File.ls!("#{File.cwd!}/screenshots") |> Enum.count == 1
+    assert File.exists?("#{File.cwd!()}/screenshots")
+    assert File.ls!("#{File.cwd!()}/screenshots") |> Enum.count() == 1
 
-    File.rm_rf! "#{File.cwd!}/screenshots"
+    File.rm_rf!("#{File.cwd!()}/screenshots")
     Application.put_env(:wallaby, :screenshot_on_failure, nil)
   end
 end

--- a/integration_test/cases/browser/select_test.exs
+++ b/integration_test/cases/browser/select_test.exs
@@ -22,11 +22,11 @@ defmodule Wallaby.Integration.Browser.SelectTest do
         |> find(select("My Select"))
 
       assert select
-      |> selected?(option("Option 2")) == false
+             |> selected?(option("Option 2")) == false
 
       assert select
-      |> click(option("Option 2"))
-      |> selected?(option("Option 2")) == true
+             |> click(option("Option 2"))
+             |> selected?(option("Option 2")) == true
     end
   end
 
@@ -34,9 +34,9 @@ defmodule Wallaby.Integration.Browser.SelectTest do
     test "returns a boolean if the option is selected", %{page: page} do
       page
       |> find(select("My Select"))
-      |> find(option("Option 2"), & refute Element.selected?(&1))
+      |> find(option("Option 2"), &refute(Element.selected?(&1)))
       |> click(option("Option 2"))
-      |> find(option("Option 2"), & assert Element.selected?(&1))
+      |> find(option("Option 2"), &assert(Element.selected?(&1)))
     end
   end
 end

--- a/integration_test/cases/browser/send_keys_test.exs
+++ b/integration_test/cases/browser/send_keys_test.exs
@@ -12,12 +12,12 @@ defmodule Wallaby.Integration.Browser.SendKeysTest do
       |> send_keys(Query.text_field("Name"), ["Chris", :tab, "c@keathley.io"])
 
       assert page
-      |> find(Query.text_field("Name"))
-      |> has_value?("Chris")
+             |> find(Query.text_field("Name"))
+             |> has_value?("Chris")
 
       assert page
-      |> find(Query.text_field("email"))
-      |> has_value?("c@keathley.io")
+             |> find(Query.text_field("email"))
+             |> has_value?("c@keathley.io")
     end
   end
 

--- a/integration_test/cases/browser/send_keys_to_active_element_test.exs
+++ b/integration_test/cases/browser/send_keys_to_active_element_test.exs
@@ -13,12 +13,12 @@ defmodule Wallaby.Integration.Browser.SendKeysToActiveElementTest do
       |> send_keys(["Chris", :tab, "c@keathley.io"])
 
       assert page
-      |> find(Query.text_field("Name"))
-      |> has_value?("Chris")
+             |> find(Query.text_field("Name"))
+             |> has_value?("Chris")
 
       assert page
-      |> find(Query.text_field("email"))
-      |> has_value?("c@keathley.io")
+             |> find(Query.text_field("email"))
+             |> has_value?("c@keathley.io")
     end
   end
 end

--- a/integration_test/cases/browser/visible_test.exs
+++ b/integration_test/cases/browser/visible_test.exs
@@ -7,12 +7,12 @@ defmodule Wallaby.Integration.Browser.VisibleTest do
     test "determines if the element is visible to the user", %{page: page} do
       page
       |> find(Query.css("#visible"))
-      |> Element.visible?
+      |> Element.visible?()
       |> assert
 
       page
       |> find(Query.css("#invisible", visible: false))
-      |> Element.visible?
+      |> Element.visible?()
       |> refute
     end
 
@@ -28,10 +28,10 @@ defmodule Wallaby.Integration.Browser.VisibleTest do
 
     test "returns a boolean", %{page: page} do
       assert page
-      |> visible?(Query.css("#visible")) == true
+             |> visible?(Query.css("#visible")) == true
 
       assert page
-      |> visible?(Query.css("#invisible")) == false
+             |> visible?(Query.css("#invisible")) == false
     end
   end
 

--- a/integration_test/cases/browser/window_handles_test.exs
+++ b/integration_test/cases/browser/window_handles_test.exs
@@ -10,6 +10,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New tab"))
+
     :timer.sleep(500)
 
     handles = window_handles(session)
@@ -24,12 +25,15 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
     session
     |> focus_window(initial_handle)
     |> click(Query.link("New window"))
+
     :timer.sleep(500)
 
     handles2 = window_handles(session)
     assert length(handles2) == 3
 
-    new_window_handle = Enum.find(handles2, fn handle -> handle not in [initial_handle, new_tab_handle] end)
+    new_window_handle =
+      Enum.find(handles2, fn handle -> handle not in [initial_handle, new_tab_handle] end)
+
     focus_window(session, new_window_handle)
 
     assert new_window_handle == window_handle(session)
@@ -44,6 +48,7 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New tab"))
+
     :timer.sleep(500)
 
     new_tab_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
@@ -57,9 +62,11 @@ defmodule Wallaby.Integration.Browser.WindowHandlesTest do
 
     session
     |> click(Query.link("New window"))
+
     :timer.sleep(500)
 
-    new_window_handle = Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
+    new_window_handle =
+      Enum.find(window_handles(session), fn handle -> handle != initial_handle end)
 
     session
     |> focus_window(new_window_handle)

--- a/integration_test/cases/element/send_keys_test.exs
+++ b/integration_test/cases/element/send_keys_test.exs
@@ -12,14 +12,14 @@ defmodule Wallaby.Integration.Element.SendKeysTest do
     test "sends keys to the specified element", %{page: page} do
       page
       |> click(@email_field)
-      |> find(@name_field, fn(element) ->
+      |> find(@name_field, fn element ->
         assert element
-        |> Element.send_keys("Chris")
-        |> Element.value == "Chris"
+               |> Element.send_keys("Chris")
+               |> Element.value() == "Chris"
       end)
-      |> find(@email_field, fn(email) ->
+      |> find(@email_field, fn email ->
         assert email
-        |> Element.value == ""
+               |> Element.value() == ""
       end)
     end
   end

--- a/integration_test/cases/inspect_test.exs
+++ b/integration_test/cases/inspect_test.exs
@@ -4,34 +4,36 @@ defmodule Wallaby.Integration.InspectTest do
 
   describe "inspect/2" do
     test "prints the outerHTML of the element", %{session: session} do
-      expected = """
-      #{IO.ANSI.cyan}outerHTML:
+      expected =
+        """
+        #{IO.ANSI.cyan()}outerHTML:
 
-      #{IO.ANSI.reset}#{IO.ANSI.yellow}<body class="bootstrap index-page">
-        <h1 id="header">Test Index</h1>
-        <ul>
-          <li><a href="page_1.html">Page 1</a></li>
-          <li><a href="page_2.html">Page 2</a></li>
-          <li><a href="page_3.html">Page 3</a></li>
-        </ul>
+        #{IO.ANSI.reset()}#{IO.ANSI.yellow()}<body class="bootstrap index-page">
+          <h1 id="header">Test Index</h1>
+          <ul>
+            <li><a href="page_1.html">Page 1</a></li>
+            <li><a href="page_2.html">Page 2</a></li>
+            <li><a href="page_3.html">Page 3</a></li>
+          </ul>
 
-        <div id="parent">
-          The Parent
-          <div id="child">
-            The Child
+          <div id="parent">
+            The Parent
+            <div id="child">
+              The Child
+            </div>
           </div>
-        </div>
-      </body>#{IO.ANSI.reset}
-      """
-      |> String.replace(~r/\s/, "")
+        </body>#{IO.ANSI.reset()}
+        """
+        |> String.replace(~r/\s/, "")
 
-      actual = capture_io(fn ->
-        session
-        |> visit("/index.html")
-        |> find(Query.css("body"))
-        |> IO.inspect
-      end)
-      |> String.replace(~r/\s/, "")
+      actual =
+        capture_io(fn ->
+          session
+          |> visit("/index.html")
+          |> find(Query.css("body"))
+          |> IO.inspect()
+        end)
+        |> String.replace(~r/\s/, "")
 
       assert actual =~ expected
     end

--- a/integration_test/chrome/all_test.exs
+++ b/integration_test/chrome/all_test.exs
@@ -1,16 +1,16 @@
-Code.require_file "../tests.exs", __DIR__
+Code.require_file("../tests.exs", __DIR__)
 
 # Additional test cases supported by chromedriver
-Code.require_file "../cases/browser/file_test.exs", __DIR__
-Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
-Code.require_file "../cases/browser/click_mouse_button_test.exs", __DIR__
-Code.require_file "../cases/browser/double_click_test.exs", __DIR__
-Code.require_file "../cases/browser/button_down_test.exs", __DIR__
-Code.require_file "../cases/browser/button_up_test.exs", __DIR__
-Code.require_file "../cases/browser/hover_test.exs", __DIR__
-Code.require_file "../cases/element/hover_test.exs", __DIR__
-Code.require_file "../cases/browser/move_mouse_by_test.exs", __DIR__
-Code.require_file "../cases/browser/send_keys_to_active_element_test.exs", __DIR__
-Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
-Code.require_file "../cases/browser/window_position_test.exs", __DIR__
-Code.require_file "../chrome/capabilities_test.exs", __DIR__
+Code.require_file("../cases/browser/file_test.exs", __DIR__)
+Code.require_file("../cases/browser/js_errors_test.exs", __DIR__)
+Code.require_file("../cases/browser/click_mouse_button_test.exs", __DIR__)
+Code.require_file("../cases/browser/double_click_test.exs", __DIR__)
+Code.require_file("../cases/browser/button_down_test.exs", __DIR__)
+Code.require_file("../cases/browser/button_up_test.exs", __DIR__)
+Code.require_file("../cases/browser/hover_test.exs", __DIR__)
+Code.require_file("../cases/element/hover_test.exs", __DIR__)
+Code.require_file("../cases/browser/move_mouse_by_test.exs", __DIR__)
+Code.require_file("../cases/browser/send_keys_to_active_element_test.exs", __DIR__)
+Code.require_file("../cases/browser/window_handles_test.exs", __DIR__)
+Code.require_file("../cases/browser/window_position_test.exs", __DIR__)
+Code.require_file("../chrome/capabilities_test.exs", __DIR__)

--- a/integration_test/chrome/test_helper.exs
+++ b/integration_test/chrome/test_helper.exs
@@ -2,10 +2,10 @@ ExUnit.configure(max_cases: 4, exclude: [pending: true])
 ExUnit.start()
 
 # Load support files
-Code.require_file "../support/test_server.ex", __DIR__
-Code.require_file "../support/pages/index_page.ex", __DIR__
-Code.require_file "../support/pages/page_1.ex", __DIR__
-Code.require_file "../support/session_case.ex", __DIR__
+Code.require_file("../support/test_server.ex", __DIR__)
+Code.require_file("../support/pages/index_page.ex", __DIR__)
+Code.require_file("../support/pages/page_1.ex", __DIR__)
+Code.require_file("../support/session_case.ex", __DIR__)
 
-{:ok, server} = Wallaby.Integration.TestServer.start
+{:ok, server} = Wallaby.Integration.TestServer.start()
 Application.put_env(:wallaby, :base_url, server.base_url)

--- a/integration_test/phantom/all_test.exs
+++ b/integration_test/phantom/all_test.exs
@@ -1,5 +1,5 @@
-Code.require_file "../tests.exs", __DIR__
+Code.require_file("../tests.exs", __DIR__)
 
 # Additional test cases supported by phantom
-Code.require_file "../cases/browser/file_test.exs", __DIR__
-Code.require_file "../cases/browser/js_errors_test.exs", __DIR__
+Code.require_file("../cases/browser/file_test.exs", __DIR__)
+Code.require_file("../cases/browser/js_errors_test.exs", __DIR__)

--- a/integration_test/phantom/configuration_test.exs
+++ b/integration_test/phantom/configuration_test.exs
@@ -17,14 +17,15 @@ defmodule Wallaby.Integration.Phantom.ConfigurationTest do
   def ensure_settings_are_reset(_) do
     orig_js_errors = Application.fetch_env(:wallaby, :js_errors)
 
-    on_exit fn ->
+    on_exit(fn ->
       reset_setting(:wallaby, :js_errors, orig_js_errors)
-    end
+    end)
   end
 
   defp reset_setting(app, setting, {:ok, value}) do
     Application.put_env(app, setting, value)
   end
+
   defp reset_setting(app, setting, :error) do
     Application.delete_env(app, setting)
   end

--- a/integration_test/phantom/current_path_test.exs
+++ b/integration_test/phantom/current_path_test.exs
@@ -14,7 +14,7 @@ defmodule Wallaby.Integration.Phantom.CurrentPathTest do
   describe "current_path/1" do
     test "returns the current path", %{page: page} do
       assert page
-      |> Driver.current_path() == {:ok, "/index.html"}
+             |> Driver.current_path() == {:ok, "/index.html"}
     end
   end
 

--- a/integration_test/phantom/send_keys.exs
+++ b/integration_test/phantom/send_keys.exs
@@ -5,8 +5,8 @@ defmodule Wallaby.Integration.Phantom.SendKeys do
 
   test "navigating with key presses", %{session: session} do
     session
-    |> IndexPage.visit
+    |> IndexPage.visit()
     |> send_keys([:tab, :enter])
-    |> Page1.ensure_page_loaded
+    |> Page1.ensure_page_loaded()
   end
 end

--- a/integration_test/phantom/test_helper.exs
+++ b/integration_test/phantom/test_helper.exs
@@ -2,11 +2,10 @@ ExUnit.configure(exclude: [pending: true])
 ExUnit.start()
 
 # Load support files
-Code.require_file "../support/test_server.ex", __DIR__
-Code.require_file "../support/pages/index_page.ex", __DIR__
-Code.require_file "../support/pages/page_1.ex", __DIR__
-Code.require_file "../support/session_case.ex", __DIR__
+Code.require_file("../support/test_server.ex", __DIR__)
+Code.require_file("../support/pages/index_page.ex", __DIR__)
+Code.require_file("../support/pages/page_1.ex", __DIR__)
+Code.require_file("../support/session_case.ex", __DIR__)
 
-{:ok, server} = Wallaby.Integration.TestServer.start
+{:ok, server} = Wallaby.Integration.TestServer.start()
 Application.put_env(:wallaby, :base_url, server.base_url)
-

--- a/integration_test/selenium/all_test.exs
+++ b/integration_test/selenium/all_test.exs
@@ -1,10 +1,10 @@
-Code.require_file "../tests.exs", __DIR__
+Code.require_file("../tests.exs", __DIR__)
 
 # Additional test cases supported by selenium
-Code.require_file "../cases/browser/double_click_test.exs", __DIR__
-Code.require_file "../cases/browser/hover_test.exs", __DIR__
-Code.require_file "../cases/element/hover_test.exs", __DIR__
-Code.require_file "../cases/browser/move_mouse_by_test.exs", __DIR__
-Code.require_file "../cases/browser/window_handles_test.exs", __DIR__
-Code.require_file "../cases/browser/window_position_test.exs", __DIR__
-Code.require_file "../selenium/capabilities_test.exs", __DIR__
+Code.require_file("../cases/browser/double_click_test.exs", __DIR__)
+Code.require_file("../cases/browser/hover_test.exs", __DIR__)
+Code.require_file("../cases/element/hover_test.exs", __DIR__)
+Code.require_file("../cases/browser/move_mouse_by_test.exs", __DIR__)
+Code.require_file("../cases/browser/window_handles_test.exs", __DIR__)
+Code.require_file("../cases/browser/window_position_test.exs", __DIR__)
+Code.require_file("../selenium/capabilities_test.exs", __DIR__)

--- a/integration_test/selenium/test_helper.exs
+++ b/integration_test/selenium/test_helper.exs
@@ -2,10 +2,10 @@ ExUnit.configure(max_cases: 2, exclude: [pending: true])
 ExUnit.start()
 
 # Load support files
-Code.require_file "../support/test_server.ex", __DIR__
-Code.require_file "../support/pages/index_page.ex", __DIR__
-Code.require_file "../support/pages/page_1.ex", __DIR__
-Code.require_file "../support/session_case.ex", __DIR__
+Code.require_file("../support/test_server.ex", __DIR__)
+Code.require_file("../support/pages/index_page.ex", __DIR__)
+Code.require_file("../support/pages/page_1.ex", __DIR__)
+Code.require_file("../support/session_case.ex", __DIR__)
 
-{:ok, server} = Wallaby.Integration.TestServer.start
+{:ok, server} = Wallaby.Integration.TestServer.start()
 Application.put_env(:wallaby, :base_url, server.base_url)

--- a/integration_test/support/session_case.ex
+++ b/integration_test/support/session_case.ex
@@ -16,13 +16,14 @@ defmodule Wallaby.Integration.SessionCase do
   """
   def start_test_session(opts \\ []) do
     with {:ok, session} <- retry(2, fn -> Wallaby.start_session(opts) end),
-      do: {:ok, session}
+         do: {:ok, session}
   end
 
   @doc """
   Injects a test session into the test context
   """
   def inject_test_session(%{skip_test_session: true}), do: :ok
+
   def inject_test_session(_context) do
     {:ok, session} = start_test_session()
 
@@ -30,6 +31,7 @@ defmodule Wallaby.Integration.SessionCase do
   end
 
   defp retry(0, f), do: f.()
+
   defp retry(times, f) do
     case f.() do
       {:ok, session} -> {:ok, session}

--- a/integration_test/support/test_server.ex
+++ b/integration_test/support/test_server.ex
@@ -1,21 +1,26 @@
 defmodule Wallaby.Integration.TestServer do
   @moduledoc false
 
-  @config [ port: 0,
-            server_root:   String.to_charlist(Path.absname("./", __DIR__)),
-            document_root: String.to_charlist(Path.absname("./pages", __DIR__)),
-            server_name:   'wallaby_test',
-            directory_index: ['index.html']]
+  @config [
+    port: 0,
+    server_root: String.to_charlist(Path.absname("./", __DIR__)),
+    document_root: String.to_charlist(Path.absname("./pages", __DIR__)),
+    server_name: 'wallaby_test',
+    directory_index: ['index.html']
+  ]
 
   defstruct [:base_url, :pid]
 
   def start do
-    :inets.start
+    :inets.start()
+
     case :inets.start(:httpd, @config) do
       {:ok, pid} ->
         port = :httpd.info(pid)[:port]
         {:ok, %__MODULE__{base_url: "http://localhost:#{port}/", pid: pid}}
-      error -> error
+
+      error ->
+        error
     end
   end
 

--- a/integration_test/tests.exs
+++ b/integration_test/tests.exs
@@ -1,34 +1,34 @@
 # Common tests supported by all drivers
-Code.require_file "cases/browser_test.exs", __DIR__
-Code.require_file "cases/browser/all_test.exs", __DIR__
-Code.require_file "cases/browser/assert_css_test.exs", __DIR__
-Code.require_file "cases/browser/assert_refute_has_test.exs", __DIR__
-Code.require_file "cases/browser/assert_text_test.exs", __DIR__
-Code.require_file "cases/browser/attr_test.exs", __DIR__
-Code.require_file "cases/browser/clear_test.exs", __DIR__
-Code.require_file "cases/browser/click_button_test.exs", __DIR__
-Code.require_file "cases/browser/click_test.exs", __DIR__
-Code.require_file "cases/browser/cookies_test.exs", __DIR__
-Code.require_file "cases/browser/current_path_test.exs", __DIR__
-Code.require_file "cases/browser/dialog_test.exs", __DIR__
-Code.require_file "cases/browser/execute_script_test.exs", __DIR__
-Code.require_file "cases/browser/fill_in_test.exs", __DIR__
-Code.require_file "cases/browser/find_test.exs", __DIR__
-Code.require_file "cases/browser/has_css_test.exs", __DIR__
-Code.require_file "cases/browser/has_text_test.exs", __DIR__
-Code.require_file "cases/browser/has_value_test.exs", __DIR__
-Code.require_file "cases/browser/local_storage_test.exs", __DIR__
-Code.require_file "cases/browser/navigation_test.exs", __DIR__
-Code.require_file "cases/browser/page_source_test.exs", __DIR__
-Code.require_file "cases/browser/screenshot_test.exs", __DIR__
-Code.require_file "cases/browser/select_test.exs", __DIR__
-Code.require_file "cases/browser/set_value_test.exs", __DIR__
-Code.require_file "cases/browser/send_keys_test.exs", __DIR__
-Code.require_file "cases/browser/stale_nodes_test.exs", __DIR__
-Code.require_file "cases/browser/text_test.exs", __DIR__
-Code.require_file "cases/browser/title_test.exs", __DIR__
-Code.require_file "cases/browser/visible_test.exs", __DIR__
-Code.require_file "cases/browser/window_size_test.exs", __DIR__
-Code.require_file "cases/element/send_keys_test.exs", __DIR__
-Code.require_file "cases/query_test.exs", __DIR__
-Code.require_file "cases/wallaby_test.exs", __DIR__
+Code.require_file("cases/browser_test.exs", __DIR__)
+Code.require_file("cases/browser/all_test.exs", __DIR__)
+Code.require_file("cases/browser/assert_css_test.exs", __DIR__)
+Code.require_file("cases/browser/assert_refute_has_test.exs", __DIR__)
+Code.require_file("cases/browser/assert_text_test.exs", __DIR__)
+Code.require_file("cases/browser/attr_test.exs", __DIR__)
+Code.require_file("cases/browser/clear_test.exs", __DIR__)
+Code.require_file("cases/browser/click_button_test.exs", __DIR__)
+Code.require_file("cases/browser/click_test.exs", __DIR__)
+Code.require_file("cases/browser/cookies_test.exs", __DIR__)
+Code.require_file("cases/browser/current_path_test.exs", __DIR__)
+Code.require_file("cases/browser/dialog_test.exs", __DIR__)
+Code.require_file("cases/browser/execute_script_test.exs", __DIR__)
+Code.require_file("cases/browser/fill_in_test.exs", __DIR__)
+Code.require_file("cases/browser/find_test.exs", __DIR__)
+Code.require_file("cases/browser/has_css_test.exs", __DIR__)
+Code.require_file("cases/browser/has_text_test.exs", __DIR__)
+Code.require_file("cases/browser/has_value_test.exs", __DIR__)
+Code.require_file("cases/browser/local_storage_test.exs", __DIR__)
+Code.require_file("cases/browser/navigation_test.exs", __DIR__)
+Code.require_file("cases/browser/page_source_test.exs", __DIR__)
+Code.require_file("cases/browser/screenshot_test.exs", __DIR__)
+Code.require_file("cases/browser/select_test.exs", __DIR__)
+Code.require_file("cases/browser/set_value_test.exs", __DIR__)
+Code.require_file("cases/browser/send_keys_test.exs", __DIR__)
+Code.require_file("cases/browser/stale_nodes_test.exs", __DIR__)
+Code.require_file("cases/browser/text_test.exs", __DIR__)
+Code.require_file("cases/browser/title_test.exs", __DIR__)
+Code.require_file("cases/browser/visible_test.exs", __DIR__)
+Code.require_file("cases/browser/window_size_test.exs", __DIR__)
+Code.require_file("cases/element/send_keys_test.exs", __DIR__)
+Code.require_file("cases/query_test.exs", __DIR__)
+Code.require_file("cases/wallaby_test.exs", __DIR__)


### PR DESCRIPTION
I realized our integration tests weren't formatted in #481 because I forgot to include the `integration_test` test folder in `.formatter.exs`.