### PR TITLE
Add additional build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
       if: steps.deps-cache.outputs.cache-hit != 'true'
       run: mix deps.get
 
+    - name: Compile
+      run: mix compile --force --warnings-as-errors
+
+    - name: Check formatting
+      run: mix format --check-formatted
+      if: matrix.elixir == '1.9.x'
+
     - name: Run Credo
       run: mix credo --strict
 


### PR DESCRIPTION
This adds two additional checks to the build.

1. Fails the build if there's compilation warnings (within wallaby, not dependencies)
2. Ensures code does not need formatting.

Since there's some differences in formatting between Elixir 1.7.x and 1.9.x, this only runs the formatting check on Elixir 1.9.x.