### PR TITLE
Tests: Allow send_json_resp/3 to encode map as json

### DIFF
--- a/test/support/http_client_case.ex
+++ b/test/support/http_client_case.ex
@@ -39,10 +39,14 @@ defmodule Wallaby.HttpClientCase do
   @doc """
   Sends a response with the json content type
   """
-  @spec send_json_resp(Conn.t(), Conn.status(), Conn.body()) :: Conn.t()
-  def send_json_resp(conn, status_code, body) do
+  @spec send_json_resp(Conn.t(), Conn.status(), term) :: Conn.t()
+  def send_json_resp(conn, status_code, body) when is_binary(body) do
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(status_code, body)
+  end
+
+  def send_json_resp(conn, status_code, body) do
+    send_json_resp(conn, status_code, Jason.encode!(body))
   end
 end

--- a/test/wallaby/experimental/selenium/webdriver_client_test.exs
+++ b/test/wallaby/experimental/selenium/webdriver_client_test.exs
@@ -20,14 +20,14 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert %{"desiredCapabilities" => capabilities} == conn.body_params
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{new_session_id}",
-          "status": 0,
-          "value": {
-            "acceptSslCerts": false,
-            "browserName": "phantomjs"
+        send_json_resp(conn, 200, %{
+          "sessionId" => "#{new_session_id}",
+          "status" => 0,
+          "value" => %{
+            "acceptSslCerts" => false,
+            "browserName" => "phantomjs"
           }
-        }>)
+        })
       end)
 
       assert {:ok, response} = Client.create_session(base_url, capabilities)
@@ -40,11 +40,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "DELETE", "/session/#{session.id}", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, response} = Client.delete_session(session)
@@ -67,11 +67,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": [{"ELEMENT": "#{element_id}"}]
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => [%{"ELEMENT" => "#{element_id}"}]
+        })
       end)
 
       assert {:ok, [element]} = Client.find_elements(session, query)
@@ -99,11 +99,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": [{"ELEMENT": "#{element_id}"}]
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => [%{"ELEMENT" => "#{element_id}"}]
+          })
         end
       )
 
@@ -127,11 +127,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": [{"#{@web_element_identifier}": "#{element_id}"}]
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => [%{"#{@web_element_identifier}" => "#{element_id}"}]
+        })
       end)
 
       assert {:ok, [element]} = Client.find_elements(session, query)
@@ -160,11 +160,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"value" => [value]}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -181,10 +181,10 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/value",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0
+          })
         end
       )
 
@@ -218,13 +218,13 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/value",
         fn conn ->
-          send_json_resp(conn, 500, ~s<{
-            "sessionId": "#{session.id}",
-            "status": null,
-            "value": {
-              "class": "org.openqa.selenium.StaleElementReferenceException"
+          send_json_resp(conn, 500, %{
+            "sessionId" => session.id,
+            "status" => nil,
+            "value" => %{
+              "class" => "org.openqa.selenium.StaleElementReferenceException"
             }
-          }>)
+          })
         end
       )
 
@@ -242,11 +242,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/clear",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -262,10 +262,10 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/clear",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0
+          })
         end
       )
 
@@ -297,13 +297,13 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/clear",
         fn conn ->
-          send_json_resp(conn, 500, ~s<{
-            "sessionId": "#{session.id}",
-            "status": null,
-            "value": {
-              "class": "org.openqa.selenium.StaleElementReferenceException"
+          send_json_resp(conn, 500, %{
+            "sessionId" => session.id,
+            "status" => nil,
+            "value" => %{
+              "class" => "org.openqa.selenium.StaleElementReferenceException"
             }
-        }>)
+          })
         end
       )
 
@@ -321,11 +321,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/click",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => %{}
+          })
         end
       )
 
@@ -343,11 +343,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/text",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": ""
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => ""
+          })
         end
       )
 
@@ -365,11 +365,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/title",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{page_title}"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "#{page_title}"
+          })
         end
       )
 
@@ -388,11 +388,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "password"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "password"
+          })
         end
       )
 
@@ -409,11 +409,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"url" => url}
 
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert :ok = Client.visit(session, url)
@@ -426,11 +426,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       url = "http://www.google.com"
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/url", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": "#{url}"
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "#{url}"
+        })
       end)
 
       assert {:ok, ^url} = Client.current_url(session)
@@ -443,11 +443,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       url = "http://www.google.com/search"
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/url", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": "#{url}"
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "#{url}"
+        })
       end)
 
       assert {:ok, "/search"} = Client.current_path(session)
@@ -464,11 +464,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/selected",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": true
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => true
+          })
         end
       )
 
@@ -486,11 +486,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/displayed",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": true
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => true
+          })
         end
       )
 
@@ -506,13 +506,13 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/displayed",
         fn conn ->
-          send_json_resp(conn, 500, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 10,
-            "value": {
-              "class": "org.openqa.selenium.StaleElementReferenceException"
+          send_json_resp(conn, 500, %{
+            "sessionId" => session.id,
+            "status" => 10,
+            "value" => %{
+              "class" => "org.openqa.selenium.StaleElementReferenceException"
             }
-          }>)
+          })
         end
       )
 
@@ -530,11 +530,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/size",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "not quite sure"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "not quite sure"
+          })
         end
       )
 
@@ -552,11 +552,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/rect",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "not quite sure"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "not quite sure"
+          })
         end
       )
 
@@ -574,11 +574,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         "GET",
         "/session/#{session.id}/screenshot",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{Base.encode64(screenshot_data)}"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "#{Base.encode64(screenshot_data)}"
+          })
         end
       )
 
@@ -591,11 +591,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/cookie", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": [{"domain": "localhost"}]
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => [%{"domain" => "localhost"}]
+        })
       end)
 
       assert {:ok, [%{"domain" => "localhost"}]} = Client.cookies(session)
@@ -612,11 +612,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"cookie" => %{"name" => key, "value" => value}}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": []
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => []
+        })
       end)
 
       assert {:ok, []} = Client.set_cookie(session, key, value)
@@ -633,11 +633,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"height" => height, "width" => width}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.set_window_size(session, width, height)
@@ -649,14 +649,14 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/window/current/size", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {
-            "height": 600,
-            "width": 400
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{
+            "height" => 600,
+            "width" => 400
           }
-        }>)
+        })
       end)
 
       assert {:ok, %{"height" => 600, "width" => 400}} == Client.get_window_size(session)
@@ -673,11 +673,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"x" => x_coordinate, "y" => y_coordinate}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.set_window_position(session, x_coordinate, y_coordinate)
@@ -689,14 +689,14 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/window/current/position", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {
-            "x": 600,
-            "y": 400
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{
+            "x" => 600,
+            "y" => 400
           }
-        }>)
+        })
       end)
 
       assert {:ok, %{"x" => 600, "y" => 400}} == Client.get_window_position(session)
@@ -708,11 +708,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "POST", "/session/#{session.id}/window/current/maximize", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} == Client.maximize_window(session)
@@ -727,11 +727,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"script" => "localStorage.clear()", "args" => [2, "a"]}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": null
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => nil
+        })
       end)
 
       assert {:ok, nil} = Client.execute_script(session, "localStorage.clear()", [2, "a"])
@@ -747,11 +747,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": null
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => nil
+        })
       end)
 
       assert {:ok, nil} = Client.send_keys(session, keys)
@@ -771,11 +771,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
 
           assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -791,11 +791,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"type" => "browser"}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": []
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => []
+        })
       end)
 
       assert {:ok, []} = Client.log(session)
@@ -810,11 +810,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       Bypass.expect(bypass, "GET", "/session/#{session.id}/source", fn conn ->
         conn = parse_body(conn)
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": "#{page_source}"
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "#{page_source}"
+        })
       end)
 
       assert {:ok, ^page_source} = Client.page_source(session)
@@ -826,11 +826,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/window_handles", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": ["some-window-handle", "other-window-handle"]
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => ["some-window-handle", "other-window-handle"]
+        })
       end)
 
       assert {:ok, ["some-window-handle", "other-window-handle"]} = Client.window_handles(session)
@@ -842,11 +842,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "GET", "/session/#{session.id}/window_handle", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": "my-window-handle"
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "my-window-handle"
+        })
       end)
 
       assert {:ok, "my-window-handle"} = Client.window_handle(session)
@@ -862,11 +862,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"name" => window_handle_id, "handle" => window_handle_id}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.focus_window(session, window_handle_id)
@@ -878,11 +878,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "DELETE", "/session/#{session.id}/window", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.close_window(session)
@@ -904,11 +904,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
                  }
                }
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_element)
@@ -924,11 +924,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"id" => frame_id}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_id)
@@ -941,11 +941,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       Bypass.expect(bypass, "POST", "/session/#{session.id}/frame", fn conn ->
         conn = parse_body(conn)
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.focus_frame(session, frame_id)
@@ -957,11 +957,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "POST", "/session/#{session.id}/frame/parent", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.focus_parent_frame(session)
@@ -977,11 +977,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"element" => element.id}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.move_mouse_to(nil, element)
@@ -997,11 +997,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"xoffset" => x_offset, "yoffset" => y_offset}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.move_mouse_to(session, nil, x_offset, y_offset)
@@ -1023,11 +1023,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
                  "yoffset" => y_offset
                }
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.move_mouse_to(nil, element, x_offset, y_offset)
@@ -1042,11 +1042,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"button" => 0}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.click(session, :left)
@@ -1058,11 +1058,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "POST", "/session/#{session.id}/doubleclick", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.double_click(session)
@@ -1077,11 +1077,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"button" => 0}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.button_down(session, :left)
@@ -1096,11 +1096,11 @@ defmodule Wallaby.Experimental.Selenium.WebdriverClientTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"button" => 0}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": {}
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, %{}} = Client.button_up(session, :left)

--- a/test/wallaby/http_client_test.exs
+++ b/test/wallaby/http_client_test.exs
@@ -13,11 +13,11 @@ defmodule Wallaby.HTTPClientTest do
         assert get_req_header(conn, "accept") == ["application/json"]
         assert get_req_header(conn, "content-type") == ["application/json"]
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "abc123",
-          "status": 0,
-          "value": null
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => "abc123",
+          "status" => 0,
+          "value" => nil
+        })
       end)
 
       assert {:ok, _} = Client.request(:post, bypass_url(bypass, "/my_url"), %{hello: "world"})
@@ -25,11 +25,11 @@ defmodule Wallaby.HTTPClientTest do
 
     test "with a 200 status response", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "abc123",
-          "status": 0,
-          "value": null
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => "abc123",
+          "status" => 0,
+          "value" => nil
+        })
       end)
 
       {:ok, response} = Client.request(:post, bypass_url(bypass, "/my_url"))
@@ -43,13 +43,13 @@ defmodule Wallaby.HTTPClientTest do
 
     test "with a 500 response and StaleElementReferenceException", %{bypass: bypass} do
       Bypass.expect(bypass, fn conn ->
-        send_json_resp(conn, 500, ~s<{
-          "sessionId": "abc123",
-          "status": 10,
-          "value": {
-            "class": "org.openqa.selenium.StaleElementReferenceException"
+        send_json_resp(conn, 500, %{
+          "sessionId" => "abc123",
+          "status" => 10,
+          "value" => %{
+            "class" => "org.openqa.selenium.StaleElementReferenceException"
           }
-        }>)
+        })
       end)
 
       assert {:error, :stale_reference} = Client.request(:post, bypass_url(bypass, "/my_url"))
@@ -59,13 +59,13 @@ defmodule Wallaby.HTTPClientTest do
       expected_message = "message from an obsure error"
 
       Bypass.expect(bypass, fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "abc123",
-          "status": 13,
-          "value": {
-            "message": "#{expected_message}"
+        send_json_resp(conn, 200, %{
+          "sessionId" => "abc123",
+          "status" => 13,
+          "value" => %{
+            "message" => "#{expected_message}"
           }
-        }>)
+        })
       end)
 
       assert {:error, ^expected_message} = Client.request(:post, bypass_url(bypass, "/my_url"))
@@ -86,13 +86,13 @@ defmodule Wallaby.HTTPClientTest do
       expected_message = "The session could not be created"
 
       Bypass.expect(bypass, fn conn ->
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "abc123",
-          "value": {
-            "error": "An error",
-            "message": "#{expected_message}"
+        send_json_resp(conn, 200, %{
+          "sessionId" => "abc123",
+          "value" => %{
+            "error" => "An error",
+            "message" => "#{expected_message}"
           }
-        }>)
+        })
       end)
 
       assert_raise RuntimeError, expected_message, fn ->

--- a/test/wallaby/phantom/driver_test.exs
+++ b/test/wallaby/phantom/driver_test.exs
@@ -22,14 +22,14 @@ defmodule Wallaby.Phantom.DriverTest do
         assert "/session" == conn.request_path
         assert %{"desiredCapabilities" => capabilities} == conn.body_params
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{new_session_id}",
-          "status": 0,
-          "value": {
-            "acceptSslCerts": false,
-            "browserName": "phantomjs"
+        send_json_resp(conn, 200, %{
+          "sessionId" => new_session_id,
+          "status" => 0,
+          "value" => %{
+            "acceptSslCerts" => false,
+            "browserName" => "phantomjs"
           }
-        }>)
+        })
       end)
 
       assert {:ok, response} = Driver.create_session(base_url, capabilities)
@@ -42,11 +42,11 @@ defmodule Wallaby.Phantom.DriverTest do
       session = build_session_for_bypass(bypass)
 
       Bypass.expect(bypass, "DELETE", "/session/#{session.id}", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => %{}
+        })
       end)
 
       assert {:ok, response} = Driver.delete(session)
@@ -71,11 +71,11 @@ defmodule Wallaby.Phantom.DriverTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
-        send_json_resp(conn, 200, ~s<{
-              "sessionId": "#{session.id}",
-              "status": 0,
-              "value": [{"ELEMENT": "#{element_id}"}]
-            }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => [%{"ELEMENT" => element_id}]
+        })
       end)
 
       assert {:ok, [element]} = Driver.find_elements(session, query)
@@ -105,11 +105,11 @@ defmodule Wallaby.Phantom.DriverTest do
 
           assert conn.body_params == %{"using" => "css selector", "value" => ".blue"}
 
-          send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": [{"ELEMENT": "#{element_id}"}]
-      }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => [%{"ELEMENT" => element_id}]
+          })
         end
       )
 
@@ -140,11 +140,11 @@ defmodule Wallaby.Phantom.DriverTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"value" => [value]}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -163,11 +163,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/clear",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -186,11 +186,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "POST",
         "/session/#{session.id}/element/#{element.id}/click",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => %{}
+          })
         end
       )
 
@@ -209,11 +209,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/text",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": ""
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => ""
+          })
         end
       )
 
@@ -232,11 +232,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/title",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{page_title}"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "#{page_title}"
+          })
         end
       )
 
@@ -256,11 +256,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/attribute/#{attribute_name}",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "password"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "password"
+          })
         end
       )
 
@@ -282,11 +282,11 @@ defmodule Wallaby.Phantom.DriverTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"url" => url}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => %{}
+          })
         end
       )
 
@@ -325,11 +325,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/url",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{url}"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "#{url}"
+          })
         end
       )
 
@@ -348,11 +348,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/url",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{url}"
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => "#{url}"
+          })
         end
       )
 
@@ -371,11 +371,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/selected",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": true
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => true
+          })
         end
       )
 
@@ -394,11 +394,11 @@ defmodule Wallaby.Phantom.DriverTest do
         "GET",
         "/session/#{session.id}/element/#{element.id}/displayed",
         fn conn ->
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": true
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => true
+          })
         end
       )
 
@@ -412,13 +412,13 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/element/#{element.id}/displayed", fn conn ->
-        send_json_resp(conn, 500, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 10,
-            "value": {
-              "class": "org.openqa.selenium.StaleElementReferenceException"
-            }
-          }>)
+        send_json_resp(conn, 500, %{
+          "sessionId" => session.id,
+          "status" => 10,
+          "value" => %{
+            "class" => "org.openqa.selenium.StaleElementReferenceException"
+          }
+        })
       end)
 
       assert {:error, :stale_reference} = Driver.displayed(element)
@@ -433,11 +433,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/element/#{element.id}/displayed", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": true
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => true
+        })
       end)
 
       assert true = Driver.displayed!(element)
@@ -450,13 +450,13 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/element/#{element.id}/displayed", fn conn ->
-        send_json_resp(conn, 500, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 10,
-            "value": {
-              "class": "org.openqa.selenium.StaleElementReferenceException"
-            }
-          }>)
+        send_json_resp(conn, 500, %{
+          "sessionId" => session.id,
+          "status" => 10,
+          "value" => %{
+            "class" => "org.openqa.selenium.StaleElementReferenceException"
+          }
+        })
       end)
 
       assert_raise StaleReferenceError, fn ->
@@ -473,11 +473,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/element/#{element.id}/size", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "not quite sure"
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "not quite sure"
+        })
       end)
 
       assert {:ok, "not quite sure"} = Driver.size(element)
@@ -492,11 +492,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/element/#{element.id}/rect", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "not quite sure"
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "not quite sure"
+        })
       end)
 
       assert {:ok, "not quite sure"} = Driver.rect(element)
@@ -511,11 +511,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/screenshot", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{Base.encode64(screenshot_data)}"
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => "#{Base.encode64(screenshot_data)}"
+        })
       end)
 
       assert ^screenshot_data = Driver.take_screenshot(session)
@@ -529,11 +529,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/cookie", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": [{"domain": "localhost"}]
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => [%{"domain" => "localhost"}]
+        })
       end)
 
       assert {:ok, [%{"domain" => "localhost"}]} = Driver.cookies(session)
@@ -552,11 +552,11 @@ defmodule Wallaby.Phantom.DriverTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"cookie" => %{"name" => key, "value" => value}}
 
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": []
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => []
+        })
       end)
 
       assert {:ok, []} = Driver.set_cookie(session, key, value)
@@ -579,11 +579,11 @@ defmodule Wallaby.Phantom.DriverTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"height" => height, "width" => width}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {}
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => %{}
+          })
         end
       )
 
@@ -603,14 +603,15 @@ defmodule Wallaby.Phantom.DriverTest do
         "/session/#{session.id}/window/#{@window_handle_id}/size",
         fn conn ->
           conn = parse_body(conn)
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": {
-              "height": 600,
-              "width": 400
+
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => %{
+              "height" => 600,
+              "width" => 400
             }
-          }>)
+          })
         end
       )
 
@@ -631,11 +632,11 @@ defmodule Wallaby.Phantom.DriverTest do
           conn = parse_body(conn)
           assert conn.body_params == %{"script" => "localStorage.clear()", "args" => [2, "a"]}
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -657,11 +658,11 @@ defmodule Wallaby.Phantom.DriverTest do
           conn = parse_body(conn)
           assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
-          send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+          send_json_resp(conn, 200, %{
+            "sessionId" => session.id,
+            "status" => 0,
+            "value" => nil
+          })
         end
       )
 
@@ -679,11 +680,11 @@ defmodule Wallaby.Phantom.DriverTest do
         conn = parse_body(conn)
         assert conn.body_params == Wallaby.Helpers.KeyCodes.json(keys) |> Jason.decode!()
 
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": null
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => nil
+        })
       end)
 
       assert {:ok, nil} = Driver.send_keys(element, keys)
@@ -698,11 +699,11 @@ defmodule Wallaby.Phantom.DriverTest do
         conn = parse_body(conn)
         assert conn.body_params == %{"type" => "browser"}
 
-        send_json_resp(conn, 200, ~s<{
-          "sessionId": "#{session.id}",
-          "status": 0,
-          "value": []
-        }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => []
+        })
       end)
 
       assert {:ok, []} = Driver.log(session)
@@ -717,11 +718,11 @@ defmodule Wallaby.Phantom.DriverTest do
       bypass
       |> expect_fetch_logs_request(session)
       |> Bypass.expect("GET", "/session/#{session.id}/source", fn conn ->
-        send_json_resp(conn, 200, ~s<{
-            "sessionId": "#{session.id}",
-            "status": 0,
-            "value": "#{page_source}"
-          }>)
+        send_json_resp(conn, 200, %{
+          "sessionId" => session.id,
+          "status" => 0,
+          "value" => page_source
+        })
       end)
 
       assert {:ok, ^page_source} = Driver.page_source(session)
@@ -746,11 +747,11 @@ defmodule Wallaby.Phantom.DriverTest do
 
   defp expect_get_window_handle_request(bypass, session) do
     Bypass.expect(bypass, "GET", "/session/#{session.id}/window_handle", fn conn ->
-      send_json_resp(conn, 200, ~s<{
-        "sessionId": "#{session.id}",
-        "status": 0,
-        "value": "#{@window_handle_id}"
-    }>)
+      send_json_resp(conn, 200, %{
+        "sessionId" => session.id,
+        "status" => 0,
+        "value" => @window_handle_id
+      })
     end)
 
     bypass
@@ -758,11 +759,11 @@ defmodule Wallaby.Phantom.DriverTest do
 
   defp expect_fetch_logs_request(bypass, session) do
     Bypass.expect(bypass, "POST", "/session/#{session.id}/log", fn conn ->
-      send_json_resp(conn, 200, ~s<{
-        "sessionId": "#{session.id}",
-        "status": 0,
-        "value": []
-    }>)
+      send_json_resp(conn, 200, %{
+        "sessionId" => session.id,
+        "status" => 0,
+        "value" => []
+      })
     end)
 
     bypass


### PR DESCRIPTION
This adds json encoding logic to `send_json_resp/3` so we don't have to manually encode the response body. This allows responses to go from being written as a JSON string

```elixir
send_json_resp(conn, 200, ~s<{
          "sessionId": "#{new_session_id}",
          "status": 0,
          "value": {
            "acceptSslCerts": false,
            "browserName": "phantomjs"
          }
        }>)
```

to be able to use an Elixir map

```elixir
send_json_resp(conn, 200, %{
          "sessionId" => new_session_id,
          "status" => 0,
          "value" => %{
            "acceptSslCerts" => false,
            "browserName" => "phantomjs"
          }
        })
```

This improvement has a few benefits:
* We don't have to write raw JSON in tests (or send a data structure through `Jason.encode!/1`)
* The formatter will take care of spacing
* Assertions may be come easier when comparing the map used for the server response to the result returned by the function under test.