### PR TITLE
Automatically run mix docs with MIX_ENV=docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Wallaby.Mixfile do
         "coveralls.html": :test,
         "coveralls.json": :test,
         "test.all": :test,
-        "test.drivers": :test
+        "test.drivers": :test,
+        docs: :docs
       ],
       test_coverage: [tool: ExCoveralls],
       test_paths: test_paths(@selected_driver),


### PR DESCRIPTION
This makes it so we can run `mix docs` instead of `MIX_ENV=docs mix docs`.