### PR TITLE
Fixes TestDriver already_started test failures

### DIFF
--- a/test/wallaby/browser_test.exs
+++ b/test/wallaby/browser_test.exs
@@ -8,7 +8,9 @@ defmodule Wallaby.BrowserTest do
   alias Wallaby.Session
 
   defmodule TestDriver do
-    def start_link() do
+    use Agent
+
+    def start_link(_opts) do
       Agent.start_link(fn -> [] end, name: __MODULE__)
     end
 
@@ -40,7 +42,7 @@ defmodule Wallaby.BrowserTest do
   describe "visit/2" do
     setup do
       ensure_setting_is_reset(:wallaby, :base_url)
-      {:ok, _} = TestDriver.start_link()
+      start_supervised!(TestDriver)
       :ok
     end
 


### PR DESCRIPTION
Occasionally the test suite will fail like this

    1) test visit/2 relative path with leading slash, base url no trailing slash (Wallaby.BrowserTest)
        test/wallaby/browser_test.exs:56
        ** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.4095.0>}}
        stacktrace:
          test/wallaby/browser_test.exs:43: Wallaby.BrowserTest.__ex_unit_setup_0/1
          test/wallaby/browser_test.exs:1: Wallaby.BrowserTest.__ex_unit__/2

https://github.com/aaronrenner/wallaby/runs/409174774#step:6:70

This appears to be because the named TestDriver process doesn't always finish shutting down before the next setup block runs. By using `start_supervised!/1`, this PR links the TestSupervisor instance to the test supervisor, which ensures shutdown occurs before the next test is started.