### PR TITLE
Remove .x elixir/erlang versions in test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,17 @@ jobs:
 
     strategy:
       matrix:
-        otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x]
+        elixir: ["1.7.4", "1.8.2", "1.9.4"]
+        include:
+          - elixir: "1.9.4"
+            otp: "21.3.8.9"
+            check_formatting: true
+          - elixir: "1.8.2"
+            otp: "21.3.8.9"
+            check_formatting: false
+          - elixir: "1.7.4"
+            otp: "21.3.8.9"
+            check_formatting: false
       fail-fast: false
 
     steps:
@@ -42,7 +51,7 @@ jobs:
 
     - name: Check formatting
       run: mix format --check-formatted
-      if: matrix.elixir == '1.9.x'
+      if: matrix.check_formatting
 
     - name: Run Credo
       run: mix credo --strict
@@ -56,8 +65,14 @@ jobs:
 
     strategy:
       matrix:
-        otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x]
+        elixir: ["1.7.4", "1.8.2", "1.9.4"]
+        include:
+          - elixir: "1.9.4"
+            otp: "21.3.8.9"
+          - elixir: "1.8.2"
+            otp: "21.3.8.9"
+          - elixir: "1.7.4"
+            otp: "21.3.8.9"
       fail-fast: false
 
     env:
@@ -93,8 +108,14 @@ jobs:
 
     strategy:
       matrix:
-        otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x]
+        elixir: ["1.7.4", "1.8.2", "1.9.4"]
+        include:
+          - elixir: "1.9.4"
+            otp: "21.3.8.9"
+          - elixir: "1.8.2"
+            otp: "21.3.8.9"
+          - elixir: "1.7.4"
+            otp: "21.3.8.9"
       fail-fast: false
 
     env:
@@ -134,8 +155,14 @@ jobs:
 
     strategy:
       matrix:
-        otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x]
+        elixir: ["1.7.4", "1.8.2", "1.9.4"]
+        include:
+          - elixir: "1.9.4"
+            otp: "21.3.8.9"
+          - elixir: "1.8.2"
+            otp: "21.3.8.9"
+          - elixir: "1.7.4"
+            otp: "21.3.8.9"
       fail-fast: false
 
     env:
@@ -176,8 +203,14 @@ jobs:
 
     strategy:
       matrix:
-        otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x]
+        elixir: ["1.7.4", "1.8.2", "1.9.4"]
+        include:
+          - elixir: "1.9.4"
+            otp: "21.3.8.9"
+          - elixir: "1.8.2"
+            otp: "21.3.8.9"
+          - elixir: "1.7.4"
+            otp: "21.3.8.9"
       fail-fast: false
 
     env:


### PR DESCRIPTION
According to this issue https://github.com/actions/setup-elixir/issues/8, the `1.9.x` syntax is no longer recommended because it can lead to 404s (an issue I ran into this morning when [testing out elixir 1.10](https://github.com/aaronrenner/wallaby/runs/410870743?check_suite_focus=true#step:3:804)).

Although this approach hard-codes the elixir versions we're using, it's also compatible with the latest elixir versions including pre-releases. This PR doesn't add Elixir 1.10 support because it requires a formatting and dialyzer change, that I thought I'd add in a subsequent PR.