### PR TITLE
Add tests for wallaby's behavior when starting chromedriver

### DIFF
--- a/test/support/application_control.ex
+++ b/test/support/application_control.ex
@@ -1,0 +1,38 @@
+defmodule Wallaby.TestSupport.ApplicationControl do
+  @moduledoc """
+  Test helpers for starting/stopping wallaby during test setup
+  """
+
+  import ExUnit.Assertions, only: [flunk: 1]
+  import ExUnit.Callbacks, only: [on_exit: 1]
+  import Wallaby.SettingsTestHelpers
+
+  @doc """
+  Stops the wallaby application and ensures its restarted
+  before the next test
+  """
+  def stop_wallaby(_) do
+    Application.stop(:wallaby)
+
+    on_exit(fn ->
+      case Application.start(:wallaby) do
+        result when result in [:ok, {:error, {:already_started, :wallaby}}] ->
+          :ok
+
+        result ->
+          flunk("failed to restart wallaby: #{inspect(result)}")
+      end
+    end)
+  end
+
+  @doc """
+  Set's the current driver to chromedriver
+
+  Note: This is not safe for use with `async: true`
+  """
+  def set_to_chromedriver(_) do
+    ensure_setting_is_reset(:wallaby, :driver)
+
+    :ok = Application.put_env(:wallaby, :driver, Wallaby.Experimental.Chrome)
+  end
+end

--- a/test/support/chrome/fake_chromedriver_script.ex
+++ b/test/support/chrome/fake_chromedriver_script.ex
@@ -1,0 +1,69 @@
+defmodule Wallaby.TestSupport.Chrome.FakeChromedriverScript do
+  @moduledoc """
+  A fake chromedriver script that enables checking the argv options
+  passed when process is started.
+
+  This is very useful for integration style testing.
+  """
+
+  @type script_path :: String.t()
+  @type test_script_opt :: {:version, String}
+
+  @spec write_test_script!(String.t(), [test_script_opt]) :: script_path
+  def write_test_script!(directory, opts \\ []) when is_list(opts) do
+    script_name = "test_script-#{random_string()}"
+    script_path = Path.join(directory, script_name)
+    output_path = Path.join(directory, output_filename(script_name))
+    contents = script_contents(output_path, opts)
+
+    :ok = File.write(script_path, contents)
+    :ok = File.chmod(script_path, 0o755)
+
+    script_path
+  end
+
+  @spec fetch_last_argv(script_path) :: {:ok, String.t()} | {:error, :not_found}
+  def fetch_last_argv(script_path) do
+    directory = Path.dirname(script_path)
+    script_name = Path.basename(script_path)
+    output_path = Path.join(directory, output_filename(script_name))
+
+    case File.read(output_path) do
+      {:ok, contents} ->
+        last_line =
+          contents
+          |> String.split("\n", trim: true)
+          |> List.last()
+
+        {:ok, last_line}
+
+      {:error, :enoent} ->
+        {:error, :not_found}
+    end
+  end
+
+  defp script_contents(output_path, opts) do
+    version = Keyword.get(opts, :version, "79.0.3945.36")
+
+    """
+    #!/bin/sh
+
+    if [ "$1" = "--version" ]; then
+    echo "ChromeDriver #{version}"
+    else
+    echo $@ >> #{output_path}
+    fi
+    """
+  end
+
+  defp output_filename(script_name) do
+    "#{script_name}-output"
+  end
+
+  defp random_string do
+    0x100000000
+    |> :rand.uniform()
+    |> Integer.to_string(36)
+    |> String.downcase()
+  end
+end

--- a/test/support/test_workspace.ex
+++ b/test/support/test_workspace.ex
@@ -1,0 +1,31 @@
+defmodule Wallaby.TestSupport.TestWorkspace do
+  @moduledoc """
+  Test helpers that create temporary directory that exists
+  for the lifetime of the test.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  alias Wallaby.Driver.TemporaryPath
+
+  def create_test_workspace(_) do
+    workspace_path = gen_tmp_path()
+    :ok = File.mkdir_p!(workspace_path)
+
+    on_exit(fn ->
+      File.rm_rf!(workspace_path)
+    end)
+
+    [workspace_path: workspace_path]
+  end
+
+  defp gen_tmp_path do
+    base_dir =
+      Path.join(
+        System.tmp_dir!(),
+        Application.get_env(:wallaby, :tmp_dir_prefix, "")
+      )
+
+    TemporaryPath.generate(base_dir)
+  end
+end

--- a/test/wallaby/experimental/chrome_test.exs
+++ b/test/wallaby/experimental/chrome_test.exs
@@ -1,0 +1,58 @@
+defmodule Wallaby.Experimental.ChromeTest do
+  use ExUnit.Case, async: false
+
+  import Wallaby.SettingsTestHelpers
+  import Wallaby.TestSupport.ApplicationControl
+  import Wallaby.TestSupport.TestWorkspace
+
+  alias Wallaby.TestSupport.Chrome.FakeChromedriverScript
+
+  setup [
+    :stop_wallaby,
+    :set_to_chromedriver,
+    :create_test_workspace
+  ]
+
+  @moduletag :capture_log
+
+  test "starting wallaby with chromedriver calls the executable with the correct options", %{
+    workspace_path: workspace_path
+  } do
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+
+    script_path = FakeChromedriverScript.write_test_script!(workspace_path)
+    Application.put_env(:wallaby, :chromedriver, path: script_path)
+
+    assert :ok = Application.start(:wallaby)
+
+    # Application startup seems to call the FakeChromedriverScript async
+    Process.sleep(500)
+
+    {switches, []} =
+      case FakeChromedriverScript.fetch_last_argv(script_path) do
+        {:ok, argv} ->
+          argv
+          |> String.split()
+          |> OptionParser.parse!(switches: [], allow_nonexistent_atoms: true)
+
+        {:error, :not_found} ->
+          flunk("Fake chromedriver script not called. (Script: #{script_path})")
+      end
+
+    assert {port, remaining_switches} = Keyword.pop(switches, :port)
+    assert is_binary(port)
+
+    assert remaining_switches == [log_level: "OFF"]
+  end
+
+  test "wallaby fails to start if chromedriver's version is < 2.30", %{
+    workspace_path: workspace_path
+  } do
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+
+    script_path = FakeChromedriverScript.write_test_script!(workspace_path, version: "2.29")
+    Application.put_env(:wallaby, :chromedriver, path: script_path)
+
+    assert {:error, _} = Application.start(:wallaby)
+  end
+end


### PR DESCRIPTION
This adds some initial test coverage around how wallaby starts the chromedriver executable. I figured I should add some test coverage to protect the existing behavior before making changes to address #509.

Since chromedriver is started on wallaby's application startup, these tests 

1. stop wallaby
2. make the necessary environment changes (to use fake script and chromedriver as main driver)
3. starts wallaby

The benefit of the `FakeChromedriverScript` is we can record the arguments that chromedriver is being started and assert that default and user configured options are passed correctly. It also makes it much simpler to test checks like running against an old version of chromedriver.