### PR TITLE
Add integration tests for starting phantom and chromedriver

### DIFF
--- a/integration_test/chrome/capabilities_test.exs
+++ b/integration_test/chrome/capabilities_test.exs
@@ -1,13 +1,14 @@
 defmodule Wallaby.Integration.CapabilitiesTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   use Wallaby.DSL
+
+  import Wallaby.SettingsTestHelpers
+
   alias Wallaby.Integration.SessionCase
   alias Wallaby.Experimental.Selenium.WebdriverClient
 
   setup do
-    on_exit(fn ->
-      Application.delete_env(:wallaby, :chromedriver)
-    end)
+    ensure_setting_is_reset(:wallaby, :chromedriver)
   end
 
   describe "capabilities" do

--- a/integration_test/chrome/starting_sessions_test.exs
+++ b/integration_test/chrome/starting_sessions_test.exs
@@ -1,0 +1,87 @@
+defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
+  use ExUnit.Case, async: false
+
+  import Wallaby.SettingsTestHelpers
+  import Wallaby.TestSupport.ApplicationControl
+  import Wallaby.TestSupport.TestScriptUtils
+  import Wallaby.TestSupport.TestWorkspace
+
+  alias Wallaby.Experimental.Chrome
+  alias Wallaby.TestSupport.Chrome.ChromeTestScript
+
+  @moduletag :capture_log
+
+  setup [:stop_wallaby, :create_test_workspace]
+
+  test "works when chromedriver starts immediately", %{workspace_path: workspace_path} do
+    {:ok, chromedriver_path} = Chrome.find_chromedriver_executable()
+
+    test_script_path =
+      chromedriver_path
+      |> ChromeTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+    Application.put_env(:wallaby, :chromedriver, path: test_script_path)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+  end
+
+  test "starting a session boots chromedriver with the default options", %{
+    workspace_path: workspace_path
+  } do
+    {:ok, chromedriver_path} = Chrome.find_chromedriver_executable()
+
+    test_script_path =
+      chromedriver_path
+      |> ChromeTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+    Application.put_env(:wallaby, :chromedriver, path: test_script_path)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    assert [invocation] = ChromeTestScript.get_invocations(test_script_path) |> Enum.take(-1)
+
+    assert {switches, [^chromedriver_path]} =
+             invocation
+             |> String.split()
+             |> OptionParser.parse!(switches: [], allow_nonexistent_atoms: true)
+
+    switches
+    |> assert_switch(:port, fn port -> String.to_integer(port) > 0 end)
+    |> assert_switch(:log_level, &match?("OFF", &1))
+    |> assert_no_remaining_switches()
+  end
+
+  test "application does not start when chromedriver version < 2.30", %{
+    workspace_path: workspace_path
+  } do
+    test_script_path =
+      ChromeTestScript.build_version_mock_script(version: "2.29")
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+    Application.put_env(:wallaby, :chromedriver, path: test_script_path)
+
+    assert {:error, _} = Application.start(:wallaby)
+  end
+
+  test "application starts when chromedriver version >= 2.30", %{
+    workspace_path: workspace_path
+  } do
+    test_script_path =
+      ChromeTestScript.build_version_mock_script(version: "2.30")
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :chromedriver)
+    Application.put_env(:wallaby, :chromedriver, path: test_script_path)
+
+    assert :ok = Application.start(:wallaby)
+  end
+end

--- a/integration_test/chrome/starting_sessions_test.exs
+++ b/integration_test/chrome/starting_sessions_test.exs
@@ -11,7 +11,7 @@ defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
 
   @moduletag :capture_log
 
-  setup [:stop_wallaby, :create_test_workspace]
+  setup [:restart_wallaby_on_exit!, :stop_wallaby, :create_test_workspace]
 
   test "works when chromedriver starts immediately", %{workspace_path: workspace_path} do
     {:ok, chromedriver_path} = Chrome.find_chromedriver_executable()

--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -10,7 +10,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
   @moduletag :capture_log
 
-  setup [:stop_wallaby, :create_test_workspace]
+  setup [:restart_wallaby_on_exit!, :stop_wallaby, :create_test_workspace]
 
   test "works when phantomjs starts immediately", %{
     workspace_path: workspace_path

--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -1,0 +1,148 @@
+defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
+  use ExUnit.Case, async: false
+
+  import Wallaby.SettingsTestHelpers
+  import Wallaby.TestSupport.ApplicationControl
+  import Wallaby.TestSupport.TestScriptUtils
+  import Wallaby.TestSupport.TestWorkspace
+
+  alias Wallaby.TestSupport.Phantom.PhantomTestScript
+
+  @moduletag :capture_log
+
+  setup [:stop_wallaby, :create_test_workspace]
+
+  test "works when phantomjs starts immediately", %{
+    workspace_path: workspace_path
+  } do
+    test_script_path =
+      Wallaby.phantomjs_path()
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+  end
+
+  test "starts a session with default args when none are configured", %{
+    workspace_path: workspace_path
+  } do
+    original_phantomjs_path = Wallaby.phantomjs_path()
+
+    test_script_path =
+      original_phantomjs_path
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs_args)
+    Application.delete_env(:wallaby, :phantomjs_args)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    for invocation <- PhantomTestScript.get_invocations(test_script_path) do
+      assert {switches, [^original_phantomjs_path]} =
+               invocation
+               |> String.split()
+               |> OptionParser.parse!(switches: [], allow_nonexistent_atoms: true)
+
+      switches
+      |> assert_switch(:webdriver, fn port -> String.to_integer(port) > 0 end)
+      |> assert_switch(:local_storage_path, &File.dir?/1)
+      |> assert_no_remaining_switches()
+    end
+  end
+
+  test "starts a session with the configured arguments", %{workspace_path: workspace_path} do
+    original_phantomjs_path = Wallaby.phantomjs_path()
+
+    test_script_path =
+      original_phantomjs_path
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs_args)
+
+    Application.put_env(
+      :wallaby,
+      :phantomjs_args,
+      "--webdriver-loglevel=DEBUG --output-encoding=UTF-8"
+    )
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    for invocation <- PhantomTestScript.get_invocations(test_script_path) do
+      assert {switches, [^original_phantomjs_path]} =
+               invocation
+               |> String.split()
+               |> OptionParser.parse!(switches: [], allow_nonexistent_atoms: true)
+
+      switches
+      |> assert_switch(:webdriver, fn port -> String.to_integer(port) > 0 end)
+      |> assert_switch(:local_storage_path, &File.dir?/1)
+      |> assert_switch(:webdriver_loglevel, &match?("DEBUG", &1))
+      |> assert_switch(:output_encoding, &match?("UTF-8", &1))
+      |> assert_no_remaining_switches()
+    end
+  end
+
+  test "starts one phantomjs instance per scheduler by default", %{workspace_path: workspace_path} do
+    original_phantomjs_path = Wallaby.phantomjs_path()
+
+    test_script_path =
+      original_phantomjs_path
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
+
+    ensure_setting_is_reset(:wallaby, :pool_size)
+    Application.delete_env(:wallaby, :pool_size)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    assert test_script_path |> PhantomTestScript.get_invocations() |> length() ==
+             :erlang.system_info(:schedulers_online)
+  end
+
+  test "allows size of phantomjs instance pool to be configured", %{
+    workspace_path: workspace_path
+  } do
+    desired_pool_size = 1
+    original_phantomjs_path = Wallaby.phantomjs_path()
+
+    test_script_path =
+      original_phantomjs_path
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(workspace_path)
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
+
+    ensure_setting_is_reset(:wallaby, :pool_size)
+    Application.put_env(:wallaby, :pool_size, desired_pool_size)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    assert ^desired_pool_size =
+             test_script_path |> PhantomTestScript.get_invocations() |> length()
+  end
+end

--- a/test/support/application_control.ex
+++ b/test/support/application_control.ex
@@ -1,0 +1,31 @@
+defmodule Wallaby.TestSupport.ApplicationControl do
+  @moduledoc """
+  Test helpers for starting/stopping wallaby during test setup
+  """
+
+  import ExUnit.Assertions, only: [flunk: 1]
+  import ExUnit.Callbacks, only: [on_exit: 1]
+  import Wallaby.SettingsTestHelpers
+
+  @doc """
+  Stops the wallaby application and ensures its restarted
+  before the next test
+  """
+  def stop_wallaby(_) do
+    Application.stop(:wallaby)
+
+    on_exit(fn ->
+      # Stops wallaby if it's been started so it can be
+      # restarted successfully
+      Application.stop(:wallaby)
+
+      case Application.start(:wallaby) do
+        :ok ->
+          :ok
+
+        result ->
+          flunk("failed to restart wallaby: #{inspect(result)}")
+      end
+    end)
+  end
+end

--- a/test/support/application_control.ex
+++ b/test/support/application_control.ex
@@ -7,12 +7,19 @@ defmodule Wallaby.TestSupport.ApplicationControl do
   import ExUnit.Callbacks, only: [on_exit: 1]
 
   @doc """
-  Stops the wallaby application and ensures its restarted
-  before the next test
+  Stops the wallaby application
   """
   def stop_wallaby(_) do
     Application.stop(:wallaby)
+  end
 
+  @doc """
+  Restarts wallaby after the current test process exits.
+
+  This ensures wallaby is restarted in a fresh state after
+  a test that modifies wallaby's startup config.
+  """
+  def restart_wallaby_on_exit!(_) do
     on_exit(fn ->
       # Stops wallaby if it's been started so it can be
       # restarted successfully

--- a/test/support/application_control.ex
+++ b/test/support/application_control.ex
@@ -5,7 +5,6 @@ defmodule Wallaby.TestSupport.ApplicationControl do
 
   import ExUnit.Assertions, only: [flunk: 1]
   import ExUnit.Callbacks, only: [on_exit: 1]
-  import Wallaby.SettingsTestHelpers
 
   @doc """
   Stops the wallaby application and ensures its restarted

--- a/test/support/chrome/chrome_test_script.ex
+++ b/test/support/chrome/chrome_test_script.ex
@@ -54,11 +54,7 @@ defmodule Wallaby.TestSupport.Chrome.ChromeTestScript do
     |> File.read()
     |> case do
       {:ok, contents} ->
-        contents
-        |> String.split("\n")
-        # Remove last line because echoing into a file automatically appends
-        # a newline and would make it look like an extra invocation
-        |> List.delete_at(-1)
+        String.split(contents, "\n", trim: true)
 
       {:error, :enoent} ->
         []

--- a/test/support/chrome/chrome_test_script.ex
+++ b/test/support/chrome/chrome_test_script.ex
@@ -1,0 +1,72 @@
+defmodule Wallaby.TestSupport.Chrome.ChromeTestScript do
+  @moduledoc """
+  Generates scripts that allow testing wallaby's interaction with the
+  chromedriver executable
+  """
+
+  @type test_script_opt :: {:startup_delay, non_neg_integer}
+  @type path :: String.t()
+
+  @doc """
+  Builds a wrapper script around the given chromedriver executable
+  that logs script invocations and allows for controlling startup delay.
+  """
+  @spec build_wrapper_script(String.t(), [test_script_opt]) :: String.t()
+  def build_wrapper_script(chromedriver_path, opts \\ []) when is_list(opts) do
+    startup_delay = Keyword.get(opts, :startup_delay, 0)
+
+    """
+    #!/bin/sh
+
+    echo "#{chromedriver_path} $@" >> "$0-output"
+
+    sleep #{startup_delay / 1000}
+
+    #{chromedriver_path} $@
+    """
+  end
+
+  @type version_mock_script_opt :: {:version, String.t()}
+
+  @doc """
+  Builds a test script used to test version constraints
+  """
+  @spec build_version_mock_script([version_mock_script_opt]) :: String.t()
+  def build_version_mock_script(opts) do
+    version = Keyword.get(opts, :version, "79.0.3945.36")
+
+    """
+    #!/bin/sh
+
+    if [ "$1" = "--version" ]; then
+      echo "ChromeDriver #{version}"
+    fi
+    """
+  end
+
+  @doc """
+  Returns a list of command-line invocations for a given script instance
+  """
+  @spec get_invocations(path) :: [String.t()]
+  def get_invocations(script_path) when is_binary(script_path) do
+    script_path
+    |> output_path()
+    |> File.read()
+    |> case do
+      {:ok, contents} ->
+        contents
+        |> String.split("\n")
+        # Remove last line because echoing into a file automatically appends
+        # a newline and would make it look like an extra invocation
+        |> List.delete_at(-1)
+
+      {:error, :enoent} ->
+        []
+    end
+  end
+
+  @spec output_path(path) :: path
+  defp output_path(script_path) do
+    script_path <> "-output"
+  end
+end

--- a/test/support/phantom/phantom_test_script.ex
+++ b/test/support/phantom/phantom_test_script.ex
@@ -1,0 +1,54 @@
+defmodule Wallaby.TestSupport.Phantom.PhantomTestScript do
+  @moduledoc """
+  Generates scripts that allow testing wallaby's interaction with the
+  phantomjs executable
+  """
+
+  @type test_script_opt :: {:startup_delay, non_neg_integer}
+  @type path :: String.t()
+
+  @doc """
+  Builds a wrapper script around the given phantomjs executable
+  that logs script invocations and allows for controlling startup delay.
+  """
+  @spec build_wrapper_script(String.t(), [test_script_opt]) :: String.t()
+  def build_wrapper_script(phantom_path, opts \\ []) when is_list(opts) do
+    startup_delay = Keyword.get(opts, :startup_delay, 0)
+
+    """
+    #!/bin/sh
+
+    echo "#{phantom_path} $@" >> "$0-output"
+
+    sleep #{startup_delay / 1000}
+
+    #{phantom_path} $@
+    """
+  end
+
+  @doc """
+  Returns a list of command-line invocations for a given script instance
+  """
+  @spec get_invocations(path) :: [String.t()]
+  def get_invocations(script_path) when is_binary(script_path) do
+    script_path
+    |> output_path()
+    |> File.read()
+    |> case do
+      {:ok, contents} ->
+        contents
+        |> String.split("\n")
+        # Remove last line because echoing into a file automatically appends
+        # a newline and would make it look like an extra invocation
+        |> List.delete_at(-1)
+
+      {:error, :enoent} ->
+        []
+    end
+  end
+
+  @spec output_path(path) :: path
+  defp output_path(script_path) do
+    script_path <> "-output"
+  end
+end

--- a/test/support/phantom/phantom_test_script.ex
+++ b/test/support/phantom/phantom_test_script.ex
@@ -36,11 +36,7 @@ defmodule Wallaby.TestSupport.Phantom.PhantomTestScript do
     |> File.read()
     |> case do
       {:ok, contents} ->
-        contents
-        |> String.split("\n")
-        # Remove last line because echoing into a file automatically appends
-        # a newline and would make it look like an extra invocation
-        |> List.delete_at(-1)
+        String.split(contents, "\n", trim: true)
 
       {:error, :enoent} ->
         []

--- a/test/support/test_script_utils.ex
+++ b/test/support/test_script_utils.ex
@@ -1,0 +1,65 @@
+defmodule Wallaby.TestSupport.TestScriptUtils do
+  @moduledoc """
+  Helper functions for working with webdriver test scripts
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Pops `switch` from `switches` so each switch value can be checked.
+
+  Raises an `AssertionError` if `switch` key does not exist, or `fun` does not return true.
+  """
+  @spec assert_switch(keyword, atom, (term -> boolean)) :: keyword | no_return
+  def assert_switch(switches, switch, fun \\ fn _ -> true end)
+      when is_list(switches) and is_atom(switch) and is_function(fun, 1) do
+    case Keyword.pop_first(switches, switch) do
+      {nil, remaining_switches} ->
+        flunk("""
+        Switch #{inspect(switch)} not found
+
+        Switches: #{inspect(remaining_switches, pretty: true)}
+        """)
+
+      {value, remaining_switches} ->
+        assert fun.(value)
+
+        remaining_switches
+    end
+  end
+
+  @doc """
+  Asserts all switches have been analyzed and removed from `switches`
+  """
+  @spec assert_no_remaining_switches(keyword) :: :ok | no_return
+  def assert_no_remaining_switches(switches) when is_list(switches) do
+    assert switches == [],
+           """
+           Expected all switches to have already been checked, but got:
+
+           #{inspect(switches, pretty: true)}
+           """
+  end
+
+  @doc """
+  Writes `script_contents` into a test script in
+  `base_directory` and makes it executable.
+  """
+  @spec write_test_script!(String.t(), String.t()) :: String.t() | no_return
+  def write_test_script!(script_contents, base_directory) do
+    script_name = "test_script-#{random_string()}"
+    script_path = Path.join([base_directory, script_name])
+
+    File.write!(script_path, script_contents)
+    File.chmod!(script_path, 0o755)
+
+    script_path
+  end
+
+  defp random_string do
+    0x100000000
+    |> :rand.uniform()
+    |> Integer.to_string(36)
+    |> String.downcase()
+  end
+end

--- a/test/support/test_workspace.ex
+++ b/test/support/test_workspace.ex
@@ -1,0 +1,31 @@
+defmodule Wallaby.TestSupport.TestWorkspace do
+  @moduledoc """
+  Test helpers that create temporary directory that exists
+  for the lifetime of the test.
+  """
+
+  import ExUnit.Callbacks, only: [on_exit: 1]
+
+  alias Wallaby.Driver.TemporaryPath
+
+  def create_test_workspace(_) do
+    workspace_path = gen_tmp_path()
+    :ok = File.mkdir_p!(workspace_path)
+
+    on_exit(fn ->
+      File.rm_rf!(workspace_path)
+    end)
+
+    [workspace_path: workspace_path]
+  end
+
+  defp gen_tmp_path do
+    base_dir =
+      Path.join(
+        System.tmp_dir!(),
+        Application.get_env(:wallaby, :tmp_dir_prefix, "")
+      )
+
+    TemporaryPath.generate(base_dir)
+  end
+end


### PR DESCRIPTION
This adds integration tests for around starting wallaby and the underlying phantomjs and chromedriver processes. These tests establish a pattern of how to test a webdriver server's startup and will make it easier to work on the following issues:

* #509 - need ability to pass custom options to chromedriver
* #423 - wallaby crashes on startup when phantomjs pool takes too long to start.

I chose to test this via integration tests because I'm thinking this style of test will give us the most flexibility to address #423 while having test coverage to ensure wallaby as a whole continues to function as users expect.