### PR TITLE
Fix issues with phantomjs path handling

### DIFF
--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -8,6 +8,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
   alias Wallaby.Phantom
   alias Wallaby.TestSupport.Phantom.PhantomTestScript
+  alias Wallaby.TestSupport.TestWorkspace
 
   @moduletag :capture_log
 
@@ -148,27 +149,15 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   end
 
   test "works with a path in the home directory" do
-    workspace_path = "~/.wallaby-tmp-#{random_string()}"
-    expanded_workspace_path = Path.expand(workspace_path)
-    :ok = File.mkdir_p!(expanded_workspace_path)
-    on_exit(fn -> File.rm_rf!(expanded_workspace_path) end)
+    test_script_path =
+      "~/.wallaby-tmp-#{random_string()}"
+      |> TestWorkspace.mkdir!()
+      |> write_phantom_wrapper_script!()
 
     pool_size = 1
-    {:ok, original_phantomjs_path} = Phantom.find_phantomjs_executable()
-
-    expanded_test_script_path =
-      original_phantomjs_path
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(expanded_workspace_path)
-
-    non_expanded_test_script_path =
-      Path.join(
-        workspace_path,
-        Path.basename(expanded_test_script_path)
-      )
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
-    Application.put_env(:wallaby, :phantomjs, non_expanded_test_script_path)
+    Application.put_env(:wallaby, :phantomjs, test_script_path)
 
     ensure_setting_is_reset(:wallaby, :pool_size)
     Application.put_env(:wallaby, :pool_size, pool_size)
@@ -177,8 +166,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
     assert {:ok, session} = Wallaby.start_session()
 
-    assert expanded_test_script_path |> PhantomTestScript.get_invocations() |> length() ==
-             pool_size
+    assert test_script_path |> PhantomTestScript.get_invocations() |> length() == pool_size
   end
 
   test "fails to start when phantomjs path is configured incorrectly" do
@@ -186,6 +174,14 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
     Application.put_env(:wallaby, :phantomjs, "this-really-should-not-exist-#{random_string()}")
 
     assert {:error, _} = Application.start(:wallaby)
+  end
+
+  defp write_phantom_wrapper_script!(base_dir, opts \\ []) do
+    {:ok, original_phantomjs_path} = Phantom.find_phantomjs_executable()
+
+    original_phantomjs_path
+    |> PhantomTestScript.build_wrapper_script(opts)
+    |> write_test_script!(base_dir)
   end
 
   defp random_string do

--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -6,6 +6,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   import Wallaby.TestSupport.TestScriptUtils
   import Wallaby.TestSupport.TestWorkspace
 
+  alias Wallaby.Phantom
   alias Wallaby.TestSupport.Phantom.PhantomTestScript
 
   @moduletag :capture_log
@@ -144,5 +145,53 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
     assert ^desired_pool_size =
              test_script_path |> PhantomTestScript.get_invocations() |> length()
+  end
+
+  test "works with a path in the home directory" do
+    workspace_path = "~/.wallaby-tmp-#{random_string()}"
+    expanded_workspace_path = Path.expand(workspace_path)
+    :ok = File.mkdir_p!(expanded_workspace_path)
+    on_exit(fn -> File.rm_rf!(expanded_workspace_path) end)
+
+    pool_size = 1
+    {:ok, original_phantomjs_path} = Phantom.find_phantomjs_executable()
+
+    expanded_test_script_path =
+      original_phantomjs_path
+      |> PhantomTestScript.build_wrapper_script()
+      |> write_test_script!(expanded_workspace_path)
+
+    non_expanded_test_script_path =
+      Path.join(
+        workspace_path,
+        Path.basename(expanded_test_script_path)
+      )
+
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, non_expanded_test_script_path)
+
+    ensure_setting_is_reset(:wallaby, :pool_size)
+    Application.put_env(:wallaby, :pool_size, pool_size)
+
+    assert :ok = Application.start(:wallaby)
+
+    assert {:ok, session} = Wallaby.start_session()
+
+    assert expanded_test_script_path |> PhantomTestScript.get_invocations() |> length() ==
+             pool_size
+  end
+
+  test "fails to start when phantomjs path is configured incorrectly" do
+    ensure_setting_is_reset(:wallaby, :phantomjs)
+    Application.put_env(:wallaby, :phantomjs, "this-really-should-not-exist-#{random_string()}")
+
+    assert {:error, _} = Application.start(:wallaby)
+  end
+
+  defp random_string do
+    0x100000000
+    |> :rand.uniform()
+    |> Integer.to_string(36)
+    |> String.downcase()
   end
 end

--- a/lib/wallaby/phantom.ex
+++ b/lib/wallaby/phantom.ex
@@ -77,18 +77,15 @@ defmodule Wallaby.Phantom do
   def find_phantomjs_executable do
     phantom_path = Application.get_env(:wallaby, :phantomjs, "phantomjs")
 
-    result =
-      [Path.expand(phantom_path), phantom_path]
-      |> Enum.find(&System.find_executable/1)
-      |> case do
-        path when is_binary(path) ->
-          {:ok, path}
+    [Path.expand(phantom_path), phantom_path]
+    |> Enum.find(&System.find_executable/1)
+    |> case do
+      path when is_binary(path) ->
+        {:ok, path}
 
-        nil ->
-          {:error, :not_found}
-      end
-
-    result
+      nil ->
+        {:error, :not_found}
+    end
   end
 
   @doc false

--- a/lib/wallaby/phantom/server.ex
+++ b/lib/wallaby/phantom/server.ex
@@ -8,8 +8,7 @@ defmodule Wallaby.Phantom.Server do
 
   @type os_pid :: non_neg_integer
 
-  @type start_link_opt ::
-          {:phantom_path, String.t()}
+  @type start_link_opt :: {:phantom_path, String.t()}
 
   @spec start_link([start_link_opt]) :: GenServer.on_start()
   def start_link(args \\ []) do

--- a/lib/wallaby/phantom/server_pool.ex
+++ b/lib/wallaby/phantom/server_pool.ex
@@ -3,9 +3,9 @@ defmodule Wallaby.Phantom.ServerPool do
 
   @instance __MODULE__
 
-  def child_spec(_) do
+  def child_spec([phantomjs_path]) when is_binary(phantomjs_path) do
     @instance
-    |> :poolboy.child_spec(poolboy_config(), [])
+    |> :poolboy.child_spec(poolboy_config(), phantom_path: phantomjs_path)
     |> from_deprecated_child_spec()
   end
 

--- a/test/support/phantom/phantom_test_script.ex
+++ b/test/support/phantom/phantom_test_script.ex
@@ -33,6 +33,7 @@ defmodule Wallaby.TestSupport.Phantom.PhantomTestScript do
   def get_invocations(script_path) when is_binary(script_path) do
     script_path
     |> output_path()
+    |> Path.expand()
     |> File.read()
     |> case do
       {:ok, contents} ->

--- a/test/support/test_script_utils.ex
+++ b/test/support/test_script_utils.ex
@@ -50,8 +50,10 @@ defmodule Wallaby.TestSupport.TestScriptUtils do
     script_name = "test_script-#{random_string()}"
     script_path = Path.join([base_directory, script_name])
 
-    File.write!(script_path, script_contents)
-    File.chmod!(script_path, 0o755)
+    expanded_script_path = Path.expand(script_path)
+
+    File.write!(expanded_script_path, script_contents)
+    File.chmod!(expanded_script_path, 0o755)
 
     script_path
   end

--- a/test/support/test_workspace.ex
+++ b/test/support/test_workspace.ex
@@ -8,15 +8,29 @@ defmodule Wallaby.TestSupport.TestWorkspace do
 
   alias Wallaby.Driver.TemporaryPath
 
+  @deprecated "Use mkdir!/0 inside test instead"
   def create_test_workspace(_) do
-    workspace_path = gen_tmp_path()
-    :ok = File.mkdir_p!(workspace_path)
-
-    on_exit(fn ->
-      File.rm_rf!(workspace_path)
-    end)
+    workspace_path = mkdir!()
 
     [workspace_path: workspace_path]
+  end
+
+  @doc """
+  Create a directory that will be removed
+  after the test exits.
+  """
+  @spec mkdir!(String.t()) :: String.t() | no_return
+  def mkdir!(path \\ gen_tmp_path()) do
+    :ok =
+      path
+      |> Path.expand()
+      |> File.mkdir_p!()
+
+    on_exit(fn ->
+      File.rm_rf!(path)
+    end)
+
+    path
   end
 
   defp gen_tmp_path do


### PR DESCRIPTION
This fixes a couple issues:

1. If the user configures their app like this:
    ```elixir
    config :wallaby, phantomjs: "wrong-path"
    ```
    and a `phantomjs` executable is in the path, wallaby will ignore the incorrect configuration and use the `phantomjs` executable on the path instead. This behavior is surprising and could lead to a user accidentally using the wrong version of phantomjs. It also makes the `Driver.validate` callback difficult to test if phantomjs is installed.
2. If the user configures wallaby to reference an install in their home directory, 
    ```elixir
    config :wallaby, phantomjs: "~/Downloads/phantomjs"
    ```
      the `validate` callback succeeds, but the workers in the server pool fail to start because the server pool gets its phantomjs path a different way. This PR now passes phantomjs path that's used during `validate` to the `Wallaby.Phantom.ServerPool` so we only have to look up the phantomjs path once.

## Additional info

This also updates the test helpers to work with non-expanded paths ("~/path/in/home/dir"). I'm also planning on submitting several follow up PRs.

1. Add similar tests and fixes for Chromedriver
2. Update other tests to use `TestWorkspace.mkdir!/1` when needed instead of calling the setup function `create_test_workspace` (which I marked as deprecated). I'm realizing that creating the test workspace on demand in the test provides more flexibility than doing it automatically in the setup block.
3. Remove `Wallaby.phantomjs_path`. This function doesn't expand the path or try to expand the executable. Instead the app should be using `Wallaby.Phantom.find_phantomjs_executable/0`.

I am thinking I'll do these as follow up PRs instead of on this PR, in order to keep things readable. 