### PR TITLE
Remove Wallaby.phantomjs_path/0

### DIFF
--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -17,10 +17,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   test "works when phantomjs starts immediately", %{
     workspace_path: workspace_path
   } do
-    test_script_path =
-      Wallaby.phantomjs_path()
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(workspace_path)
+    test_script_path = write_phantom_wrapper_script!(workspace_path)
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
     Application.put_env(:wallaby, :phantomjs, test_script_path)
@@ -33,12 +30,8 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   test "starts a session with default args when none are configured", %{
     workspace_path: workspace_path
   } do
-    original_phantomjs_path = Wallaby.phantomjs_path()
-
-    test_script_path =
-      original_phantomjs_path
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(workspace_path)
+    {:ok, original_phantomjs_path} = Phantom.find_phantomjs_executable()
+    test_script_path = write_phantom_wrapper_script!(workspace_path)
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
     Application.put_env(:wallaby, :phantomjs, test_script_path)
@@ -64,12 +57,8 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   end
 
   test "starts a session with the configured arguments", %{workspace_path: workspace_path} do
-    original_phantomjs_path = Wallaby.phantomjs_path()
-
-    test_script_path =
-      original_phantomjs_path
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(workspace_path)
+    {:ok, original_phantomjs_path} = Phantom.find_phantomjs_executable()
+    test_script_path = write_phantom_wrapper_script!(workspace_path)
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
     Application.put_env(:wallaby, :phantomjs, test_script_path)
@@ -102,12 +91,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
   end
 
   test "starts one phantomjs instance per scheduler by default", %{workspace_path: workspace_path} do
-    original_phantomjs_path = Wallaby.phantomjs_path()
-
-    test_script_path =
-      original_phantomjs_path
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(workspace_path)
+    test_script_path = write_phantom_wrapper_script!(workspace_path)
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
     Application.put_env(:wallaby, :phantomjs, test_script_path)
@@ -127,12 +111,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
     workspace_path: workspace_path
   } do
     desired_pool_size = 1
-    original_phantomjs_path = Wallaby.phantomjs_path()
-
-    test_script_path =
-      original_phantomjs_path
-      |> PhantomTestScript.build_wrapper_script()
-      |> write_test_script!(workspace_path)
+    test_script_path = write_phantom_wrapper_script!(workspace_path)
 
     ensure_setting_is_reset(:wallaby, :phantomjs)
     Application.put_env(:wallaby, :phantomjs, test_script_path)

--- a/lib/wallaby.ex
+++ b/lib/wallaby.ex
@@ -106,11 +106,6 @@ defmodule Wallaby do
     Application.get_env(:wallaby, :js_logger, :stdio)
   end
 
-  @doc false
-  def phantomjs_path do
-    Application.get_env(:wallaby, :phantomjs, "phantomjs")
-  end
-
   def driver do
     case System.get_env("WALLABY_DRIVER") do
       "chrome" ->

--- a/lib/wallaby/phantom/server/server_state.ex
+++ b/lib/wallaby/phantom/server/server_state.ex
@@ -28,19 +28,19 @@ defmodule Wallaby.Phantom.Server.ServerState do
     :phantom_os_pid
   ]
 
-  @type workspace_path :: String.t()
+  @type path :: String.t()
 
   @type new_opt ::
           {:port_number, port_number}
-          | {:phantom_path, String.t()}
           | {:phantom_args, [String.t()] | String.t()}
 
-  @spec new(workspace_path, [new_opt]) :: t
-  def new(workspace_path, params \\ []) do
+  @spec new(path, path, [new_opt]) :: t
+  def new(workspace_path, phantomjs_path, params \\ [])
+      when is_binary(workspace_path) and is_binary(phantomjs_path) do
     %__MODULE__{
       workspace_path: workspace_path,
       port_number: Keyword.get_lazy(params, :port_number, &Utils.find_available_port/0),
-      phantom_path: Keyword.get_lazy(params, :phantom_path, &Wallaby.phantomjs_path/0),
+      phantom_path: phantomjs_path,
       phantom_args:
         params
         |> Keyword.get_lazy(:phantom_args, &phantom_args_from_env/0)

--- a/lib/wallaby/phantom/server_pool.ex
+++ b/lib/wallaby/phantom/server_pool.ex
@@ -5,7 +5,7 @@ defmodule Wallaby.Phantom.ServerPool do
 
   def child_spec([phantomjs_path]) when is_binary(phantomjs_path) do
     @instance
-    |> :poolboy.child_spec(poolboy_config(), phantom_path: phantomjs_path)
+    |> :poolboy.child_spec(poolboy_config(), phantomjs_path: phantomjs_path)
     |> from_deprecated_child_spec()
   end
 


### PR DESCRIPTION
Follow up to #514.

This removes `Wallaby.phantomjs_path/0` in favor of `Wallaby.Phantom.find_phantomjs_executable/0`. This important because `Wallaby.phantomjs_path` does not do the same checking and path expansion as `Wallaby.Phantom.find_phantomjs_executeable`.

Since `phantomjs_path` is always going to be passed as an option from `ServerPool.child_spec/1`, I moved it from a keyword argument to a positional argument on `Server.start_link/1`. This provides a couple of benefits:
1. It's more clear when calling `Server.start_link/1` the `phantomjs_path` is required.
2. We can remove the fallback logic that was calling `Wallaby.phantomjs_path/0` and the tests that manipulated the application environment.

I have another PR after this where I'd like to pass `phantomjs_args` in a similar manner, thereby completely removing `Server` and `ServerState`'s dependency on the environment (and allowing the tests to be run with `async: true`).