### PR TITLE
Fix issue where chromedriver starts on incorrect path

### DIFF
--- a/lib/wallaby/exceptions.ex
+++ b/lib/wallaby/exceptions.ex
@@ -90,6 +90,10 @@ end
 defmodule Wallaby.DependencyError do
   defexception [:message]
 
+  @type t :: %__MODULE__{
+          message: String.t()
+        }
+
   def exception(msg) do
     %__MODULE__{message: msg}
   end

--- a/test/support/chrome/chrome_test_script.ex
+++ b/test/support/chrome/chrome_test_script.ex
@@ -51,6 +51,7 @@ defmodule Wallaby.TestSupport.Chrome.ChromeTestScript do
   def get_invocations(script_path) when is_binary(script_path) do
     script_path
     |> output_path()
+    |> Path.expand()
     |> File.read()
     |> case do
       {:ok, contents} ->


### PR DESCRIPTION
This is similar to #514 but for chromedriver. This ensures that an incorrectly configured chromedriver path does not silently fall back to a chromedriver instance in the system `PATH`.