### PR TITLE
Fix screenshot file url output

### DIFF
--- a/integration_test/cases/browser/screenshot_test.exs
+++ b/integration_test/cases/browser/screenshot_test.exs
@@ -1,8 +1,11 @@
 defmodule Wallaby.Integration.Browser.ScreenshotTest do
   use Wallaby.Integration.SessionCase, async: false
-  import ExUnit.CaptureIO
 
+  import ExUnit.CaptureIO
   import Wallaby.Query, only: [css: 1]
+  import Wallaby.SettingsTestHelpers
+
+  alias Wallaby.TestSupport.TestWorkspace
 
   setup %{session: session} do
     page =
@@ -12,7 +15,14 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     {:ok, page: page}
   end
 
-  test "taking screenshots", %{page: page} do
+  @default_screenshots_path Path.join([File.cwd!(), "screenshots"])
+
+  test "taking screenshots with default settings", %{page: page} do
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.delete_env(:wallaby, :screenshot_dir)
+
+    on_exit(fn -> File.rm_rf!(@default_screenshots_path) end)
+
     element =
       page
       |> take_screenshot
@@ -32,14 +42,17 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     assert Enum.count(parent_screenshots) == 1
 
     Enum.each(element_screenshots ++ parent_screenshots, fn path ->
-      assert File.exists?(path)
+      assert_path_type(path, :absolute)
+      assert_in_directory(path, @default_screenshots_path)
+      assert_file_exists(path)
     end)
-
-    File.rm_rf!("#{File.cwd!()}/screenshots")
   end
 
-  test "users can specify the screenshot directory", %{page: page} do
-    Application.put_env(:wallaby, :screenshot_dir, "shots")
+  test "users can specify the screenshot directory with a relative path", %{page: page} do
+    screenshots_path = TestWorkspace.generate_temporary_path(".tmp-shots-%{random_string}")
+
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
 
     screenshots =
       page
@@ -49,34 +62,90 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
     assert screenshots |> Enum.count() == 1
 
     Enum.each(screenshots, fn path ->
-      assert path =~ ~r/^shots\/(.*)$/
-      assert File.exists?(path)
+      assert_path_type(path, :relative)
+      assert_in_directory(path, screenshots_path)
+      assert_file_exists(path)
     end)
+  end
 
-    Application.put_env(:wallaby, :screenshot_dir, nil)
-    File.rm_rf!("#{File.cwd!()}/shots")
+  test "users can specify the screenshot directory relative to their home directory", %{
+    page: page
+  } do
+    screenshots_path =
+      TestWorkspace.generate_temporary_path("~/.test-wallaby-screenshots-%{random_string}")
+
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+    screenshots =
+      page
+      |> take_screenshot()
+      |> Map.get(:screenshots)
+
+    assert screenshots |> Enum.count() == 1
+
+    Enum.each(screenshots, fn path ->
+      assert_path_type(path, :relative)
+      assert_in_directory(path, screenshots_path)
+      assert_file_exists(path)
+    end)
+  end
+
+  test "users can specify the screenshot directory with an absolute path", %{page: page} do
+    screenshots_path = TestWorkspace.generate_temporary_path()
+
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+    screenshots =
+      page
+      |> take_screenshot
+      |> Map.get(:screenshots)
+
+    assert screenshots |> Enum.count() == 1
+
+    Enum.each(screenshots, fn path ->
+      assert_path_type(path, :absolute)
+      assert_in_directory(path, screenshots_path)
+      assert_file_exists(path)
+    end)
   end
 
   test "users can specify the screenshot name", %{page: page} do
-    Application.put_env(:wallaby, :screenshot_dir, "shots")
+    screenshots_path = TestWorkspace.generate_temporary_path()
 
-    [screenshot_path] =
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+    [path] =
       page
       |> take_screenshot(name: "some_page")
       |> Map.get(:screenshots)
 
-    assert screenshot_path == "shots/some_page.png"
-
-    Application.put_env(:wallaby, :screenshot_dir, nil)
-    File.rm_rf!("#{File.cwd!()}/shots")
+    assert_in_directory(path, screenshots_path)
+    assert Path.basename(path) == "some_page.png"
+    assert_file_exists(path)
   end
 
   test "automatically taking screenshots on failure", %{page: page} do
-    assert_raise Wallaby.QueryError, fn ->
-      find(page, css(".some-selector"))
-    end
+    screenshots_path = TestWorkspace.generate_temporary_path()
 
-    refute File.exists?("#{File.cwd!()}/screenshots")
+    ensure_setting_is_reset(:wallaby, :screenshot_dir)
+    Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+    ensure_setting_is_reset(:wallaby, :screenshot_on_failure)
+    Application.put_env(:wallaby, :screenshot_on_failure, false)
+
+    output =
+      capture_io(fn ->
+        assert_raise Wallaby.QueryError, fn ->
+          find(page, css(".some-selector"))
+        end
+      end)
+
+    assert [] = extract_screenshot_urls(output)
+
+    refute File.exists?(screenshots_path)
 
     Application.put_env(:wallaby, :screenshot_on_failure, true)
 
@@ -87,12 +156,149 @@ defmodule Wallaby.Integration.Browser.ScreenshotTest do
         end
       end)
 
-    assert Regex.match?(~r/Screenshot taken/, output)
+    assert [screenshot_url] = extract_screenshot_urls(output)
 
-    assert File.exists?("#{File.cwd!()}/screenshots")
-    assert File.ls!("#{File.cwd!()}/screenshots") |> Enum.count() == 1
+    path = path_from_file_url!(screenshot_url)
+    assert_path_type(path, :absolute)
+    assert_in_directory(path, screenshots_path)
+    assert_file_exists(path)
+  end
 
-    File.rm_rf!("#{File.cwd!()}/screenshots")
-    Application.put_env(:wallaby, :screenshot_on_failure, nil)
+  describe "logging" do
+    test "does not log by default", %{page: page} do
+      screenshots_path = TestWorkspace.generate_temporary_path()
+
+      ensure_setting_is_reset(:wallaby, :screenshot_dir)
+      Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+      output = capture_io(fn -> take_screenshot(page) end)
+
+      assert extract_screenshot_urls(output) == []
+    end
+
+    test "logs work with the default screenshot dir", %{page: page} do
+      ensure_setting_is_reset(:wallaby, :screenshot_dir)
+      Application.delete_env(:wallaby, :screenshot_dir)
+
+      output = capture_io(fn -> take_screenshot(page, log: true) end)
+
+      assert [screenshot_path] =
+               output
+               |> extract_screenshot_urls()
+               |> Enum.map(&path_from_file_url!/1)
+
+      assert_path_type(screenshot_path, :absolute)
+      assert_in_directory(screenshot_path, @default_screenshots_path)
+      assert_file_exists(screenshot_path)
+    end
+
+    test "logs file url when the sets the screenshot_dir to a relative path", %{page: page} do
+      screenshots_path = TestWorkspace.generate_temporary_path(".tmp-shots-%{random_string}")
+
+      ensure_setting_is_reset(:wallaby, :screenshot_dir)
+      Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+      output = capture_io(fn -> take_screenshot(page, log: true) end)
+
+      assert [screenshot_path] =
+               output
+               |> extract_screenshot_urls()
+               |> Enum.map(&path_from_file_url!/1)
+
+      assert_path_type(screenshot_path, :absolute)
+      assert_in_directory(screenshot_path, screenshots_path)
+      assert_file_exists(screenshot_path)
+    end
+
+    test "logs file url when the sets the screenshot_dir to an absolute path", %{page: page} do
+      screenshots_path = TestWorkspace.generate_temporary_path()
+
+      ensure_setting_is_reset(:wallaby, :screenshot_dir)
+      Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+      output = capture_io(fn -> take_screenshot(page, log: true) end)
+
+      assert [screenshot_path] =
+               output
+               |> extract_screenshot_urls()
+               |> Enum.map(&path_from_file_url!/1)
+
+      assert_path_type(screenshot_path, :absolute)
+      assert_in_directory(screenshot_path, screenshots_path)
+      assert_file_exists(screenshot_path)
+    end
+
+    test "logs file url when the sets the screenshot_dir to a path in home dir", %{page: page} do
+      screenshots_path =
+        TestWorkspace.generate_temporary_path("~/.test wallaby screenshots-%{random_string}")
+
+      ensure_setting_is_reset(:wallaby, :screenshot_dir)
+      Application.put_env(:wallaby, :screenshot_dir, screenshots_path)
+
+      output = capture_io(fn -> take_screenshot(page, log: true) end)
+
+      assert [screenshot_path] =
+               output
+               |> extract_screenshot_urls()
+               |> Enum.map(&path_from_file_url!/1)
+
+      assert_path_type(screenshot_path, :absolute)
+      assert_in_directory(screenshot_path, screenshots_path)
+      assert_file_exists(screenshot_path)
+    end
+  end
+
+  defp assert_path_type(path, expected_path_type)
+       when expected_path_type in [:relative, :absolute] do
+    path_type = Path.type(path)
+
+    assert path_type == expected_path_type, """
+    Expected path_type to be #{inspect(expected_path_type)} but was #{inspect(path_type)}
+
+    path: #{inspect(path)}
+    """
+  end
+
+  defp assert_in_directory(path, directory) do
+    assert Path.expand(directory) == Path.expand(Path.dirname(path)), """
+    Path is not in expected directory.
+
+    path: #{inspect(path)}
+    directory: #{inspect(directory)}
+    """
+  end
+
+  defp assert_file_exists(path) do
+    assert path |> Path.expand() |> File.exists?(), """
+    File does not exist
+
+    path: #{inspect(path)}
+    """
+  end
+
+  defp extract_screenshot_urls(output) do
+    ~r/Screenshot taken, find it at (?<screenshot_url>\S+)/m
+    |> Regex.scan(output, capture: :all_but_first)
+    |> List.flatten()
+  end
+
+  defp path_from_file_url!(file_url) do
+    case URI.parse(file_url) do
+      # There is a difference between elixir 1.9 and 1.10 when checking
+      # if a URI has no host: https://github.com/elixir-lang/elixir/issues/9837
+      %URI{scheme: "file", host: host, path: path} when host in [nil, ""] and is_binary(path) ->
+        URI.decode(path)
+
+      parsed_uri ->
+        flunk("""
+        Invalid file url
+
+          url: #{inspect(file_url)}
+
+          Parsed into
+
+          #{inspect(parsed_uri, pretty: true)}
+        """)
+    end
   end
 end

--- a/integration_test/chrome/starting_sessions_test.exs
+++ b/integration_test/chrome/starting_sessions_test.exs
@@ -116,7 +116,7 @@ defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
 
   test "works with a path in the home directory" do
     test_script_path =
-      "~/.wallaby-tmp-#{random_string()}"
+      "~/.wallaby-tmp-%{random_string}"
       |> TestWorkspace.mkdir!()
       |> write_chrome_wrapper_script!()
 
@@ -136,7 +136,7 @@ defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
     Application.put_env(
       :wallaby,
       :chromedriver,
-      path: "this-really-should-not-exist-#{random_string()}"
+      path: "this-really-should-not-exist"
     )
 
     assert {:error, _} = Application.start(:wallaby)
@@ -148,12 +148,5 @@ defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
     chromedriver_path
     |> ChromeTestScript.build_wrapper_script(opts)
     |> write_test_script!(base_dir)
-  end
-
-  defp random_string do
-    0x100000000
-    |> :rand.uniform()
-    |> Integer.to_string(36)
-    |> String.downcase()
   end
 end

--- a/integration_test/phantom/starting_sessions_test.exs
+++ b/integration_test/phantom/starting_sessions_test.exs
@@ -129,7 +129,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
   test "works with a path in the home directory" do
     test_script_path =
-      "~/.wallaby-tmp-#{random_string()}"
+      "~/.wallaby-tmp-%{random_string}"
       |> TestWorkspace.mkdir!()
       |> write_phantom_wrapper_script!()
 
@@ -150,7 +150,7 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
 
   test "fails to start when phantomjs path is configured incorrectly" do
     ensure_setting_is_reset(:wallaby, :phantomjs)
-    Application.put_env(:wallaby, :phantomjs, "this-really-should-not-exist-#{random_string()}")
+    Application.put_env(:wallaby, :phantomjs, "this-really-should-not-exist")
 
     assert {:error, _} = Application.start(:wallaby)
   end
@@ -161,12 +161,5 @@ defmodule Wallaby.Integration.Phantom.StartingSessionsTest do
     original_phantomjs_path
     |> PhantomTestScript.build_wrapper_script(opts)
     |> write_test_script!(base_dir)
-  end
-
-  defp random_string do
-    0x100000000
-    |> :rand.uniform()
-    |> Integer.to_string(36)
-    |> String.downcase()
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -227,10 +227,11 @@ defmodule Wallaby.Browser do
 
     name = opts |> Keyword.get(:name, :erlang.system_time()) |> to_string
     path = path_for_screenshot(name)
-    File.write!(path, image_data)
+
+    write_screenshot!(path, image_data)
 
     if opts[:log] do
-      IO.puts("Screenshot taken, find it at file:///#{path}")
+      IO.puts("Screenshot taken, find it at #{build_file_url(path)}")
     end
 
     Map.update(screenshotable, :screenshots, [], &(&1 ++ [path]))
@@ -1220,11 +1221,23 @@ defmodule Wallaby.Browser do
   end
 
   defp path_for_screenshot(name) do
-    File.mkdir_p!(screenshot_dir())
     "#{screenshot_dir()}/#{name}.png"
+  end
+
+  defp write_screenshot!(path, image_data) do
+    expanded_path = Path.expand(path)
+    :ok = expanded_path |> Path.dirname() |> File.mkdir_p!()
+
+    :ok = File.write!(expanded_path, image_data)
+
+    :ok
   end
 
   defp screenshot_dir do
     Application.get_env(:wallaby, :screenshot_dir) || "#{File.cwd!()}/screenshots"
+  end
+
+  defp build_file_url(path) do
+    "file://" <> (path |> Path.expand() |> URI.encode())
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1234,7 +1234,7 @@ defmodule Wallaby.Browser do
   end
 
   defp screenshot_dir do
-    Application.get_env(:wallaby, :screenshot_dir, "#{File.cwd!()}/screenshots") 
+    Application.get_env(:wallaby, :screenshot_dir, "#{File.cwd!()}/screenshots")
   end
 
   defp build_file_url(path) do

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1234,7 +1234,7 @@ defmodule Wallaby.Browser do
   end
 
   defp screenshot_dir do
-    Application.get_env(:wallaby, :screenshot_dir) || "#{File.cwd!()}/screenshots"
+    Application.get_env(:wallaby, :screenshot_dir, "#{File.cwd!()}/screenshots") 
   end
 
   defp build_file_url(path) do


### PR DESCRIPTION
When wallaby takes a screenshot (either automatically or with `log: true`) it currently outputs a url like this:

```
Screenshot taken, find it at file:////home/aaron/projects/wallaby_liveview_playground/screenshots/1584041849570197413_users_have_names_in_LiveView(1).png
```
This url has an extra slash (`file:////` instead of `file:///`) which is invalid and makes it so it's not clickable in the terminal.

## Fix

This PR fixes the invalid screenshot urls and adds tests for when  `screenshot_dir` is configured with the following types of directories:
* Absolute paths
* Relative paths
* Home directory based paths
* Paths with spaces in them

## Other notes

The majority of this PR is updates to the screenshots test suite. Here are a few high-level changes to the tests
1. Ensure the various types of directories that can be set for `screenshot_dir` work as expected
2. Ensure the file urls that are output with `log: true` are valid and the files they say that were created actually exist. The private `extract_screenshot_urls/1` function grabs the URLs out of the captured output and `path_from_file_url!/1` parses and extracts the absolute path from the file url.
3. Use `Wallaby.SettingsTestHelpers` and `Wallaby.TestSupport.TestWorkspace` helpers to ensure the application environment and file system are cleaned up after the tests. Previously this wasn't always happening if a test failed.
4. Updated `Wallaby.TestSupport.TestWorkspace.mkdir!/1` to accept a `%{random_string}` placeholder in the optional path param. This placeholder is replaced inside the function and makes it so I can remove the `random_string/0` helper function that I was copying across modules. I borrowed the format of the placeholder from `Ecto.Changeset`'s placeholders in its validation messages.
5. Added a `generate_temporary_path/1` function to `Wallaby.TestSupport.TestWorkspace` that generates a path (without creating the directory) and ensures this directory is removed at the end of the test. I made this because I needed a temporary path, but wanted to ensure wallaby made the directory if it didn't exist.