### PR TITLE
Extract poolboy logic into ResourcePool module

### DIFF
--- a/lib/wallaby/utils/resource_pool.ex
+++ b/lib/wallaby/utils/resource_pool.ex
@@ -1,0 +1,60 @@
+defmodule Wallaby.Utils.ResourcePool do
+  @moduledoc false
+
+  # This is a wrapper around poolboy that makes it play nicer
+  # with Elixir's child_spec
+
+  @type pool :: GenServer.server()
+
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+    additional_opts = Keyword.take(opts, [:size, :max_overflow, :strategy])
+
+    {worker_module, worker_opts} =
+      opts
+      |> Keyword.fetch!(:worker)
+      |> extract_worker_info()
+
+    name
+    |> :poolboy.child_spec(
+      [name: {:local, name}, worker_module: worker_module] ++ additional_opts,
+      worker_opts
+    )
+    |> from_deprecated_child_spec()
+  end
+
+  @type checkout_opt :: {:block?, boolean} | {:timeout, timeout}
+
+  @spec checkout(pool, [checkout_opt]) :: {:ok, pid} | {:error, :full}
+  def checkout(pool, opts \\ []) when is_list(opts) do
+    block? = Keyword.get(opts, :block?, true)
+    timeout = Keyword.get(opts, :timeout, 5_000)
+
+    case :poolboy.checkout(pool, block?, timeout) do
+      pid when is_pid(pid) -> {:ok, pid}
+      :full -> {:error, :full}
+    end
+  end
+
+  @spec checkin(pool, pid) :: :ok
+  def checkin(pool, pid) do
+    :poolboy.checkin(pool, pid)
+  end
+
+  defp extract_worker_info(worker_def)
+  defp extract_worker_info(worker_module) when is_atom(worker_module), do: {worker_module, []}
+
+  defp extract_worker_info({worker_module, worker_opts}) when is_atom(worker_module),
+    do: {worker_module, worker_opts}
+
+  defp from_deprecated_child_spec({child_id, start_mfa, restart, shutdown, worker, modules}) do
+    %{
+      id: child_id,
+      start: start_mfa,
+      restart: restart,
+      shutdown: shutdown,
+      worker: worker,
+      modules: modules
+    }
+  end
+end

--- a/test/wallaby/utils/resource_pool_test.exs
+++ b/test/wallaby/utils/resource_pool_test.exs
@@ -1,0 +1,68 @@
+defmodule Wallaby.Utils.ResourcePoolTest do
+  use ExUnit.Case
+
+  alias Wallaby.Utils.ResourcePool
+
+  defmodule TestProcess do
+    use Agent
+
+    @default_value "hello"
+
+    def start_link(arg) do
+      initial_value =
+        case arg do
+          [] -> @default_value
+          value -> value
+        end
+
+      Agent.start_link(fn -> initial_value end)
+    end
+
+    def default_value, do: @default_value
+    def get_value(pid), do: Agent.get(pid, & &1)
+  end
+
+  test "works when started with child_spec", context do
+    assert {:ok, pool_pid} =
+             start_supervised({ResourcePool, name: context.test, worker: TestProcess})
+
+    assert {:ok, process_pid} = ResourcePool.checkout(pool_pid)
+
+    assert TestProcess.get_value(process_pid) == TestProcess.default_value()
+  end
+
+  test "allows passing options to the worker process", context do
+    assert {:ok, pool_pid} =
+             start_supervised({ResourcePool, name: context.test, worker: {TestProcess, "foo"}})
+
+    assert {:ok, process_pid} = ResourcePool.checkout(pool_pid)
+
+    assert TestProcess.get_value(process_pid) == "foo"
+  end
+
+  test "does not start when missing :name" do
+    assert_raise KeyError, fn ->
+      start_supervised({ResourcePool, worker: TestProcess})
+    end
+  end
+
+  test "does not start when missing :worker", context do
+    assert_raise KeyError, fn ->
+      start_supervised({ResourcePool, name: context.test})
+    end
+  end
+
+  test "size option limits the size", context do
+    assert {:ok, pool_pid} =
+             start_supervised(
+               {ResourcePool, name: context.test, worker: TestProcess, size: 1, max_overflow: 0}
+             )
+
+    assert {:ok, process_pid} = ResourcePool.checkout(pool_pid, block?: false)
+    assert {:error, :full} = ResourcePool.checkout(pool_pid, block?: false)
+
+    assert :ok = ResourcePool.checkin(pool_pid, process_pid)
+
+    assert {:ok, ^process_pid} = ResourcePool.checkout(pool_pid, block?: false)
+  end
+end


### PR DESCRIPTION
This wraps the poolboy logic into its own module, making it simpler to implement webdriver server pools. `Wallaby.Phantom.ServerPool` is a good example of how this simplifies implementing a pool.