### PR TITLE
Update ServerSupervisor to be a DynamicSupervisor

### DIFF
--- a/lib/wallaby/driver/process_workspace/server.ex
+++ b/lib/wallaby/driver/process_workspace/server.ex
@@ -3,6 +3,14 @@ defmodule Wallaby.Driver.ProcessWorkspace.Server do
 
   use GenServer
 
+  def child_spec([process_pid, workspace_path]) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [process_pid, workspace_path]},
+      restart: :transient
+    }
+  end
+
   @spec start_link(pid, String.t()) :: GenServer.on_start()
   def start_link(process_pid, workspace_path) do
     GenServer.start_link(__MODULE__, [process_pid, workspace_path])

--- a/lib/wallaby/driver/process_workspace/server.ex
+++ b/lib/wallaby/driver/process_workspace/server.ex
@@ -12,7 +12,8 @@ defmodule Wallaby.Driver.ProcessWorkspace.Server do
   def init([process_pid, workspace_path]) do
     Process.flag(:trap_exit, true)
     ref = Process.monitor(process_pid)
-    File.mkdir(workspace_path)
+
+    File.mkdir_p!(workspace_path)
 
     {:ok, %{ref: ref, workspace_path: workspace_path}}
   end

--- a/lib/wallaby/driver/process_workspace/server_supervisor.ex
+++ b/lib/wallaby/driver/process_workspace/server_supervisor.ex
@@ -1,24 +1,26 @@
 defmodule Wallaby.Driver.ProcessWorkspace.ServerSupervisor do
   @moduledoc false
 
-  use Supervisor
+  use DynamicSupervisor
 
   alias Wallaby.Driver.ProcessWorkspace.Server
 
   @spec start_link :: Supervisor.on_start()
   def start_link do
-    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  @spec start_server(pid, String.t()) :: Supervisor.on_start_child()
+  @spec start_server(pid, String.t()) :: DynamicSupervisor.on_start_child()
   def start_server(process_pid, workspace_path) do
-    Supervisor.start_child(__MODULE__, [process_pid, workspace_path])
+    DynamicSupervisor.start_child(__MODULE__, %{
+      id: Server,
+      start: {Server, :start_link, [process_pid, workspace_path]},
+      restart: :transient
+    })
   end
 
-  @impl Supervisor
+  @impl DynamicSupervisor
   def init([]) do
-    children = [worker(Server, [], restart: :transient)]
-
-    supervise(children, strategy: :simple_one_for_one)
+    DynamicSupervisor.init(strategy: :one_for_one)
   end
 end

--- a/lib/wallaby/driver/process_workspace/server_supervisor.ex
+++ b/lib/wallaby/driver/process_workspace/server_supervisor.ex
@@ -12,11 +12,7 @@ defmodule Wallaby.Driver.ProcessWorkspace.ServerSupervisor do
 
   @spec start_server(pid, String.t()) :: DynamicSupervisor.on_start_child()
   def start_server(process_pid, workspace_path) do
-    DynamicSupervisor.start_child(__MODULE__, %{
-      id: Server,
-      start: {Server, :start_link, [process_pid, workspace_path]},
-      restart: :transient
-    })
+    DynamicSupervisor.start_child(__MODULE__, {Server, [process_pid, workspace_path]})
   end
 
   @impl DynamicSupervisor

--- a/test/wallaby/driver/process_workspace_test.exs
+++ b/test/wallaby/driver/process_workspace_test.exs
@@ -14,6 +14,24 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
     def init([]), do: {:ok, []}
   end
 
+  defp now_in_milliseconds(), do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+  defp with_timeout(doer, timeout \\ 100),
+    do: with_timeout(doer, now_in_milliseconds(), timeout)
+
+  defp with_timeout(doer, start, timeout) do
+    doer.()
+  rescue
+    e ->
+      passed_timeout? = now_in_milliseconds() - start >= timeout
+
+      if passed_timeout? do
+        reraise e, __STACKTRACE__
+      else
+        with_timeout(doer, start, timeout)
+      end
+  end
+
   describe "create/2" do
     test "creates a workspace dir which is deleted after the process ends" do
       {:ok, test_server} = TestServer.start_link()
@@ -22,9 +40,10 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       assert File.exists?(workspace_path)
 
       TestServer.stop(test_server)
-      Process.sleep(100)
 
-      refute File.exists?(workspace_path)
+      with_timeout(fn ->
+        refute File.exists?(workspace_path)
+      end)
     end
 
     test "when workspace already exists" do
@@ -36,9 +55,10 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       assert File.exists?(workspace_path)
 
       TestServer.stop(test_server)
-      Process.sleep(100)
 
-      refute File.exists?(workspace_path)
+      with_timeout(fn ->
+        refute File.exists?(workspace_path)
+      end)
     end
 
     test "creates a workspace dir using tmp_dir_prefix setting" do

--- a/test/wallaby/driver/process_workspace_test.exs
+++ b/test/wallaby/driver/process_workspace_test.exs
@@ -14,24 +14,6 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
     def init([]), do: {:ok, []}
   end
 
-  defp now_in_milliseconds(), do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-
-  defp with_timeout(doer, timeout \\ 100),
-    do: with_timeout(doer, now_in_milliseconds(), timeout)
-
-  defp with_timeout(doer, start, timeout) do
-    doer.()
-  rescue
-    e ->
-      passed_timeout? = now_in_milliseconds() - start >= timeout
-
-      if passed_timeout? do
-        reraise e, __STACKTRACE__
-      else
-        with_timeout(doer, start, timeout)
-      end
-  end
-
   describe "create/2" do
     test "creates a workspace dir which is deleted after the process ends" do
       {:ok, test_server} = TestServer.start_link()
@@ -80,5 +62,23 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       )
 
     TemporaryPath.generate(base_dir)
+  end
+
+  defp now_in_milliseconds(), do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+  defp with_timeout(doer, timeout \\ 100),
+    do: with_timeout(doer, now_in_milliseconds(), timeout)
+
+  defp with_timeout(doer, start, timeout) do
+    doer.()
+  rescue
+    e ->
+      passed_timeout? = now_in_milliseconds() - start >= timeout
+
+      if passed_timeout? do
+        reraise e, __STACKTRACE__
+      else
+        with_timeout(doer, start, timeout)
+      end
   end
 end


### PR DESCRIPTION
Also removes call to `Process.sleep` in the test in favor of recursion with a timeout.

I was investigating some flaky tests that involved the `assert File.exists?(workspace_path)` lines in the tests, and noticed that was a `:simple_one_for_one` supervisor. Converting it to a `DynamicSupervisor` seems to have fixed flakiness.

The call to `Process.sleep` was not part of the flakiness, but I converted it to use recursion with a timeout instead. Let me know what you think about that.