### PR TITLE
Change Wallaby.Browser.sync_result from opaque to type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+### Fixes
+
+- Change Wallaby.Browser.sync_result from `@opaque` to `@type` Fixes [#540](https://github.com/elixir-wallaby/wallaby/issues/540)
+
 ## 0.26.0 (2020-06-15)
 
 ### Remove `Wallaby.Phantom`
@@ -53,161 +57,161 @@ Users are encouraged to switch to the `Wallaby.Chrome` driver, which is now the 
 
 ### Improvements
 
-* Add ability to configure the path to the ChromeDriver executable
-* Enable screenshot support for Selenium driver
-* Enable `accept_alert/2`, `dismiss_alert/2`, `accept_confirm/2`, `dismiss_confirm/2`, `accept_prompt/2`, `dismiss_prompt/2` for Selenium driver
-* Add `:log` option to `take_screenshot`, this is set to `true` when taking screenshots on failure
-* Introduce window/tab switching support: `Browser.window_handle/1`, `Browser.window_handles/1`, `Browser.focus_window/2` and `Browser.close_window/1`
-* Introduce window placement support: `Browser.window_position/1`, `Browser.move_window/3` and `Browser.maximize_window/1`
-* Introduce frame switching support: `Browser.focus_frame/2`, `Browser.focus_parent_frame/1`, `Browser.focus_default_frame/1`
-* Introduce async script support: `Browser.execute_script_async/2`, `Browser.execute_script_async/3`, and `Browser.execute_script_async/4`
-* Introduce mouse events support: `Browser.hover/2`, `Browser.move_mouse_by/3`, `Browser.double_click/1`, `Browser.button_down/2`, `Browser.button_up/2`, and a version of `Browser.click/2` that clicks in current mouse position.
+- Add ability to configure the path to the ChromeDriver executable
+- Enable screenshot support for Selenium driver
+- Enable `accept_alert/2`, `dismiss_alert/2`, `accept_confirm/2`, `dismiss_confirm/2`, `accept_prompt/2`, `dismiss_prompt/2` for Selenium driver
+- Add `:log` option to `take_screenshot`, this is set to `true` when taking screenshots on failure
+- Introduce window/tab switching support: `Browser.window_handle/1`, `Browser.window_handles/1`, `Browser.focus_window/2` and `Browser.close_window/1`
+- Introduce window placement support: `Browser.window_position/1`, `Browser.move_window/3` and `Browser.maximize_window/1`
+- Introduce frame switching support: `Browser.focus_frame/2`, `Browser.focus_parent_frame/1`, `Browser.focus_default_frame/1`
+- Introduce async script support: `Browser.execute_script_async/2`, `Browser.execute_script_async/3`, and `Browser.execute_script_async/4`
+- Introduce mouse events support: `Browser.hover/2`, `Browser.move_mouse_by/3`, `Browser.double_click/1`, `Browser.button_down/2`, `Browser.button_up/2`, and a version of `Browser.click/2` that clicks in current mouse position.
 
 ### Bugfixes
 
-* LogStore now wraps logs in a list before attempting to pass them to List functions. This was causing Wallaby to crash and would mask actual test errors.
+- LogStore now wraps logs in a list before attempting to pass them to List functions. This was causing Wallaby to crash and would mask actual test errors.
 
 ## 0.22.0 (2019-02-26)
 
 ### Improvements
 
-* Add `Query.data` to find by data attributes
-* Add selected conditions to query
-* Add functions for query options
-* Add `visible: any` option to query
-* Handle Safari and Edge stale reference errors
+- Add `Query.data` to find by data attributes
+- Add selected conditions to query
+- Add functions for query options
+- Add `visible: any` option to query
+- Handle Safari and Edge stale reference errors
 
 ### Bugfixes
 
-* allow newlines in chrome logs
-* Allow other versions of chromedriver
-* Increase the session store genserver timeout
+- allow newlines in chrome logs
+- Allow other versions of chromedriver
+- Increase the session store genserver timeout
 
 ## 0.21.0 (2018-11-19)
 
 ### Breaking changes
 
-* Removed `accept_dialogs` and `dismiss_dialogs`.
+- Removed `accept_dialogs` and `dismiss_dialogs`.
 
 ### Improvements
 
-* Improved readability of `file_test` failures
-* Allow users to specify the path to the chrome binary
-* Add Query.value and Query.attribute
-* Adds jitter to all http calls
-* Returns better error messages from obscured element responses
-* Option to configure default window size
-* Pretty printing element html
+- Improved readability of `file_test` failures
+- Allow users to specify the path to the chrome binary
+- Add Query.value and Query.attribute
+- Adds jitter to all http calls
+- Returns better error messages from obscured element responses
+- Option to configure default window size
+- Pretty printing element html
 
 ### Bugfixes
 
-* Chrome takes screenshots correctly if elements are passed to `take_screenshot`.
-* Chrome no longer spits out errors constantly.
-* Find elements that contain single quotes
+- Chrome takes screenshots correctly if elements are passed to `take_screenshot`.
+- Chrome no longer spits out errors constantly.
+- Find elements that contain single quotes
 
 ## 0.20.0 (2018-04-11)
 
 ### Breaking changes
 
-* Normalized all exception names
-* Removed `set_window_size/3`
+- Normalized all exception names
+- Removed `set_window_size/3`
 
 ### Bugfixes
 
-* Fixed issues with zombie phantom processes (#338)
+- Fixed issues with zombie phantom processes (#338)
 
 ## 0.19.2 (2017-10-28)
 
 ### Features
-* Capture JavaScript logs in chrome
-* Queries now take an optional `at:` argument with which you can specify which one of multiple matches you want returned
+
+- Capture JavaScript logs in chrome
+- Queries now take an optional `at:` argument with which you can specify which one of multiple matches you want returned
 
 ### Bugfixes
 
-* relax httpoison dependency for easier upgrading and not locking you down
-* Prevent failing if phantom jsn't installed globally
-* Fix issue with zombie phantomjs processes (#224)
-* Fix issue where temporary folders for phantomjs processes aren't deleted
+- relax httpoison dependency for easier upgrading and not locking you down
+- Prevent failing if phantom jsn't installed globally
+- Fix issue with zombie phantomjs processes (#224)
+- Fix issue where temporary folders for phantomjs processes aren't deleted
 
 ## 0.19.1 (2017-08-13)
 
 ### Bugfixes
 
-* Publish new release with an updated version of hex to fix file permissions.
+- Publish new release with an updated version of hex to fix file permissions.
 
 ## 0.19.0 (2017-08-08)
 
 ### Features
 
-* Handle alerts in chromedriver - thanks @florinpatrascu
+- Handle alerts in chromedriver - thanks @florinpatrascu
 
 ### Bugfixes
 
-* Return the correct error message for text queries.
+- Return the correct error message for text queries.
 
 ## 0.18.1 (2017-07-19)
 
 ### Bugfixes
 
-* Pass correct BEAM Metadata to chromedriver to support db_connection
-* Close all sessions when their parent process dies.
+- Pass correct BEAM Metadata to chromedriver to support db_connection
+- Close all sessions when their parent process dies.
 
 ## 0.18.0 (2017-07-17)
 
 ### Features
 
-* Support for chromedriver
+- Support for chromedriver
 
 ### Bugfixes
 
-* Capture invalid state errors
+- Capture invalid state errors
 
 ## 0.17.0 (2017-05-17)
 
 This release removes all methods declared as _deprecated_ in the 0.16 release, experimental Selenium support and much more! If you are looking to upgrade from an earlier release, it is recommended to first go to 0.16.x.
 Other goodies include improved test helpers, a cookies API and handling for JS-dialogues.
 
-
 ### Breaking Changes
 
-* Removed deprecated version of `fill_in`
-* Removed deprecated `check`
-* Removed deprecated `set_window_size`
-* Removed deprecated `send_text`
-* Removed deprecated versions of `click`
-* Removed deprecated `checked?`
-* Removed deprecated `get_current_url`
-* Removed deprecated versions of `visible?`
-* Removed deprecated versions of `all`
-* Removed deprecated versions of `attach_file`
-* Removed deprecated versions of `clear`
-* Removed deprecated `attr`
-* Removed deprecated versions of `find`
-* Removed deprecated versions of `text`
-* Removed deprecated `click_link`
-* Removed deprecated `click_button`
-* Removed depreacted `choose`
+- Removed deprecated version of `fill_in`
+- Removed deprecated `check`
+- Removed deprecated `set_window_size`
+- Removed deprecated `send_text`
+- Removed deprecated versions of `click`
+- Removed deprecated `checked?`
+- Removed deprecated `get_current_url`
+- Removed deprecated versions of `visible?`
+- Removed deprecated versions of `all`
+- Removed deprecated versions of `attach_file`
+- Removed deprecated versions of `clear`
+- Removed deprecated `attr`
+- Removed deprecated versions of `find`
+- Removed deprecated versions of `text`
+- Removed deprecated `click_link`
+- Removed deprecated `click_button`
+- Removed depreacted `choose`
 
 ### Features
 
-* New cookie API with `cookies/1` and `set_cookie/3`
-* New assert macros `assert_has/2` and `refute_has/2`
-* execute_script now returns the session again and is pipable, there is an optional callback if you need access to the return value - thanks @krankin
-* Phantom server is now compatible with escripts - thanks @aaronrenner
-* Ability to handle JavaScript dialogs via `accept_dialogs/1`, `dismiss_dialogs/1`, plus methods for alerts, confirms and prompts - thanks @padde
-* Ability to pass options for driver interaction down to the underlying hackney library through `config :wallaby, hackney_options: [your: "option"]` - thanks @aaronrenner
-* Added `check_log` option to `execute_script` - thanks @aaronrenner
-* Experimental support for selnium 2 and selenium 3 web drivers has been added, use at your own risk ;)
-* Updated hackney and httpoison dependencies - thanks @aaronrenner
-* Removed documentation for modules that aren't intended for external use - thanks @aaronrenner
-* set_value now works with text fields, checkboxes, radio buttons, and
+- New cookie API with `cookies/1` and `set_cookie/3`
+- New assert macros `assert_has/2` and `refute_has/2`
+- execute_script now returns the session again and is pipable, there is an optional callback if you need access to the return value - thanks @krankin
+- Phantom server is now compatible with escripts - thanks @aaronrenner
+- Ability to handle JavaScript dialogs via `accept_dialogs/1`, `dismiss_dialogs/1`, plus methods for alerts, confirms and prompts - thanks @padde
+- Ability to pass options for driver interaction down to the underlying hackney library through `config :wallaby, hackney_options: [your: "option"]` - thanks @aaronrenner
+- Added `check_log` option to `execute_script` - thanks @aaronrenner
+- Experimental support for selnium 2 and selenium 3 web drivers has been added, use at your own risk ;)
+- Updated hackney and httpoison dependencies - thanks @aaronrenner
+- Removed documentation for modules that aren't intended for external use - thanks @aaronrenner
+- set_value now works with text fields, checkboxes, radio buttons, and
   options. - thanks @graeme-defty
 
 ### Bugfixes
 
-* Fix spawning of phantomjs when project path contains spaces - thanks @schnittchen
-* Fixed a couple of dialyzer warnings - thanks @aaronrenner
-* Fixed incorrect malformed label warning when it was really a mismatch between expected elements found
+- Fix spawning of phantomjs when project path contains spaces - thanks @schnittchen
+- Fixed a couple of dialyzer warnings - thanks @aaronrenner
+- Fixed incorrect malformed label warning when it was really a mismatch between expected elements found
 
 ## <= 0.16.1
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -141,7 +141,7 @@ defmodule Wallaby.Browser do
   state. However, if this error does continue to occur it will cause wallaby to
   loop forever (or until the test is killed by exunit).
   """
-  @opaque sync_result :: {:ok, any()} | {:error, any()}
+  @type sync_result :: {:ok, any()} | {:error, any()}
   @spec retry((() -> sync_result), timeout) :: sync_result()
 
   def retry(f, start_time \\ current_time()) do


### PR DESCRIPTION
Fixes #539.

Changes Wallaby.Browser.sync_result from `@opaque` to `@type`.