### PR TITLE
Wrap server_test assertions in timeout helper function

### DIFF
--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,0 +1,26 @@
+defmodule Wallaby.TestSupport.Utils do
+  @moduledoc """
+  This module contains generic testing helpers.
+  """
+
+  @doc """
+  Repeatedly execute a closure, with a timeout. Useful for assertions that are relying on asyncronous operations.
+  """
+  def attempt_with_timeout(doer, timeout \\ 100),
+    do: attempt_with_timeout(doer, now_in_milliseconds(), timeout)
+
+  defp attempt_with_timeout(doer, start, timeout) do
+    doer.()
+  rescue
+    e ->
+      passed_timeout? = now_in_milliseconds() - start >= timeout
+
+      if passed_timeout? do
+        reraise e, __STACKTRACE__
+      else
+        attempt_with_timeout(doer, start, timeout)
+      end
+  end
+
+  defp now_in_milliseconds(), do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+end

--- a/test/wallaby/chrome/chromedriver/server_test.exs
+++ b/test/wallaby/chrome/chromedriver/server_test.exs
@@ -4,6 +4,7 @@ defmodule Wallaby.Chrome.Chromedriver.ServerTest do
   alias Wallaby.TestSupport.Chrome.ChromeTestScript
   alias Wallaby.TestSupport.TestScriptUtils
   alias Wallaby.TestSupport.TestWorkspace
+  alias Wallaby.TestSupport.Utils
 
   alias Wallaby.Chrome
   alias Wallaby.Chrome.Chromedriver.Server
@@ -102,8 +103,11 @@ defmodule Wallaby.Chrome.Chromedriver.ServerTest do
     kill_os_process(wrapper_script_os_pid)
 
     assert_receive {:EXIT, ^server, {:exit_status, _}}
-    refute os_process_running?(wrapper_script_os_pid)
-    refute os_process_running?(os_pid)
+
+    Utils.attempt_with_timeout(fn ->
+      refute os_process_running?(wrapper_script_os_pid)
+      refute os_process_running?(os_pid)
+    end)
   end
 
   test "crashes when chromedriver is killed" do
@@ -120,10 +124,10 @@ defmodule Wallaby.Chrome.Chromedriver.ServerTest do
 
     assert_receive {:EXIT, ^server, {:exit_status, _}}
 
-    # Since the process isn't trapping exits, let things shut down async
-    Process.sleep(100)
-    refute os_process_running?(wrapper_script_os_pid)
-    refute os_process_running?(os_pid)
+    Utils.attempt_with_timeout(fn ->
+      refute os_process_running?(wrapper_script_os_pid)
+      refute os_process_running?(os_pid)
+    end)
   end
 
   test "shuts down wrapper and chromedriver when server is stopped" do
@@ -135,8 +139,10 @@ defmodule Wallaby.Chrome.Chromedriver.ServerTest do
 
     Server.stop(server)
 
-    refute os_process_running?(wrapper_script_os_pid)
-    refute os_process_running?(os_pid)
+    Utils.attempt_with_timeout(fn ->
+      refute os_process_running?(wrapper_script_os_pid)
+      refute os_process_running?(os_pid)
+    end)
   end
 
   defp write_chrome_wrapper_script!(base_dir, opts \\ []) do

--- a/test/wallaby/driver/process_workspace_test.exs
+++ b/test/wallaby/driver/process_workspace_test.exs
@@ -3,6 +3,7 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
 
   alias Wallaby.Driver.ProcessWorkspace
   alias Wallaby.Driver.TemporaryPath
+  alias Wallaby.TestSupport.Utils
 
   defmodule TestServer do
     use GenServer
@@ -23,7 +24,7 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
 
       TestServer.stop(test_server)
 
-      with_timeout(fn ->
+      Utils.attempt_with_timeout(fn ->
         refute File.exists?(workspace_path)
       end)
     end
@@ -38,7 +39,7 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
 
       TestServer.stop(test_server)
 
-      with_timeout(fn ->
+      Utils.attempt_with_timeout(fn ->
         refute File.exists?(workspace_path)
       end)
     end
@@ -62,23 +63,5 @@ defmodule Wallaby.Driver.ProcessWorkspaceTest do
       )
 
     TemporaryPath.generate(base_dir)
-  end
-
-  defp now_in_milliseconds(), do: DateTime.utc_now() |> DateTime.to_unix(:millisecond)
-
-  defp with_timeout(doer, timeout \\ 100),
-    do: with_timeout(doer, now_in_milliseconds(), timeout)
-
-  defp with_timeout(doer, start, timeout) do
-    doer.()
-  rescue
-    e ->
-      passed_timeout? = now_in_milliseconds() - start >= timeout
-
-      if passed_timeout? do
-        reraise e, __STACKTRACE__
-      else
-        with_timeout(doer, start, timeout)
-      end
   end
 end


### PR DESCRIPTION
These tests were flakey on CI, hopefully this helps with that.