### PR TITLE
Fix Query type specifications

### DIFF
--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -98,24 +98,26 @@ defmodule Wallaby.Query do
           | :option
           | :select
           | :file_field
+          | :attribute
   @type attribute_key_value_pair :: {String.t(), String.t()}
   @type selector ::
           String.t()
-          | :attribute_key_value_pair
+          | attribute_key_value_pair()
   @type html_validation ::
           :bad_label
           | :button_type
           | nil
   @type conditions :: [
-          count: non_neg_integer,
-          text: String.t(),
+          count: integer,
+          minimum: integer,
+          maximum: integer,
+          text: String.t() | nil,
           visible: boolean() | :any,
           selected: boolean() | :any,
-          minimum: non_neg_integer,
-          at: pos_integer
+          at: integer | :all
         ]
   @type result :: list(Element.t())
-  @type opts :: nonempty_list()
+  @type opts :: list()
 
   @type t :: %__MODULE__{
           method: method(),

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -108,9 +108,9 @@ defmodule Wallaby.Query do
           | :button_type
           | nil
   @type conditions :: [
-          count: integer,
-          minimum: integer,
-          maximum: integer,
+          count: non_neg_integer,
+          minimum: non_neg_integer,
+          maximum: non_neg_integer,
           text: String.t() | nil,
           visible: boolean() | :any,
           selected: boolean() | :any,

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -114,7 +114,7 @@ defmodule Wallaby.Query do
           text: String.t() | nil,
           visible: boolean() | :any,
           selected: boolean() | :any,
-          at: integer | :all
+          at: non_neg_integer | :all
         ]
   @type result :: list(Element.t())
   @type opts :: list()


### PR DESCRIPTION
Fixes #542 
I narrowed this down to `Query.compile(@query_from_module_attribute)`. Looks like with the query created at compile time, dialyzer has more information to find discrepancies. Types in the query module were missing some possible values - I updated them to be slightly more general and cover more of valid queries. This fixes the reported bugs but there still could be more valid query structs that are not covered by the current types, so we might need to revisit this in the future.