### PR TITLE
Ensure sessions are correctly deleted from ETS by passing the pid along

### DIFF
--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -39,13 +39,13 @@ defmodule Wallaby.SessionStore do
   def handle_call({:demonitor, session}, _from, _state) do
     result =
       :ets.select(:session_store, [
-        {{{:"$1", :"$2", :"$3"}, :"$4"}, [{:==, :"$2", session.id}], [{{:"$1", :"$4"}}]}
-      ])
+        {{{:"$1", :"$2", :"$3"}, :"$4"}, [{:==, :"$2", session.id}], [{{:"$1", :"$3", :"$4"}}]}
+        ])
 
     case result do
-      [{ref, _}] ->
+      [{ref, pid, _session}] ->
         true = Process.demonitor(ref)
-        :ets.delete(:session_store, {ref, session.id})
+        :ets.delete(:session_store, {ref, session.id, pid})
 
         {:reply, :ok, nil}
 
@@ -54,13 +54,13 @@ defmodule Wallaby.SessionStore do
     end
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, _state) do
+  def handle_info({:DOWN, ref, :process, pid, _reason}, _state) do
     [session] =
       :ets.select(:session_store, [{{{:"$1", :"$2", :"$3"}, :"$4"}, [{:==, :"$1", ref}], [:"$4"]}])
 
     WebdriverClient.delete_session(session)
 
-    :ets.delete(:session_store, {ref, session.id})
+    :ets.delete(:session_store, {ref, session.id, pid})
 
     {:noreply, nil}
   end

--- a/test/wallaby/session_store_test.exs
+++ b/test/wallaby/session_store_test.exs
@@ -1,0 +1,23 @@
+defmodule Wallaby.SessionStoreTest do
+  @moduledoc false
+  use ExUnit.Case
+  alias Wallaby.{Session, SessionStore}
+
+  describe "monitor/1" do
+    test "adds session to list of active sessions" do
+      assert [] = SessionStore.list_sessions_for()
+      {:ok, session} = Wallaby.driver().start_session([])
+      :ok = SessionStore.monitor(session)
+      assert [session] = SessionStore.list_sessions_for()
+    end
+  end
+
+  describe "demonitor/1" do
+    test "adds session to list of active sessions" do
+      {:ok, session} = Wallaby.driver().start_session([])
+      :ok = SessionStore.monitor(session)
+      :ok = SessionStore.demonitor(session)
+      assert [] = SessionStore.list_sessions_for()
+    end
+  end
+end

--- a/test/wallaby/session_store_test.exs
+++ b/test/wallaby/session_store_test.exs
@@ -1,7 +1,7 @@
 defmodule Wallaby.SessionStoreTest do
   @moduledoc false
   use ExUnit.Case
-  alias Wallaby.{Session, SessionStore}
+  alias Wallaby.SessionStore
 
   describe "monitor/1" do
     test "adds session to list of active sessions" do

--- a/test/wallaby/session_store_test.exs
+++ b/test/wallaby/session_store_test.exs
@@ -13,7 +13,7 @@ defmodule Wallaby.SessionStoreTest do
   end
 
   describe "demonitor/1" do
-    test "adds session to list of active sessions" do
+    test "removes session from list of active sessions" do
       {:ok, session} = Wallaby.driver().start_session([])
       :ok = SessionStore.monitor(session)
       :ok = SessionStore.demonitor(session)


### PR DESCRIPTION
ETS records weren't being correctly removed from `SessionStore`, leaving stale sessions around in `SessionStore.list_sessions_for`. By returning the `pid` from the `:ets.select`, we can ensure a correct match & delete of the session.

Could be useful to add a `defdelegate active_sessions` in the main `Wallaby` interface that calls `SessionStore.list_sessions_for`, but didn't want to make that assumption in this PR.

Fixes the issue pointed out in #550 