### PR TITLE
Fix typespec issues

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -123,7 +123,6 @@ defmodule Wallaby.Browser do
   @type parent ::
           element
           | session
-  @type locator :: String.t()
   @type opts :: Query.opts()
 
   @default_max_wait_time 3_000
@@ -694,7 +693,7 @@ defmodule Wallaby.Browser do
   """
   @spec find(parent, Query.t(), (Element.t() -> any())) :: parent
   @spec find(parent, Query.t()) :: Element.t() | [Element.t()]
-  @spec find(parent, locator) :: Element.t() | [Element.t()]
+  @spec find(parent, String.t()) :: Element.t() | [Element.t()]
 
   def find(parent, %Query{} = query, callback) when is_function(callback) do
     results = find(parent, query)
@@ -785,7 +784,7 @@ defmodule Wallaby.Browser do
   @doc """
   Matches the Element's content with the provided text
   """
-  @spec has_text?(Element.t(), String.t()) :: boolean()
+  @spec has_text?(parent, String.t()) :: boolean()
   @spec has_text?(parent, Query.t(), String.t()) :: boolean()
 
   def has_text?(parent, query, text) do
@@ -822,7 +821,7 @@ defmodule Wallaby.Browser do
   @doc """
   Matches the Element's content with the provided text and raises if not found
   """
-  @spec assert_text(Element.t(), String.t()) :: boolean()
+  @spec assert_text(parent, String.t()) :: boolean()
   @spec assert_text(parent, Query.t(), String.t()) :: boolean()
 
   def assert_text(parent, query, text) when is_binary(text) do
@@ -911,7 +910,7 @@ defmodule Wallaby.Browser do
   Searches for CSS on the page.
   """
   @spec has_css?(parent, Query.t(), String.t()) :: boolean()
-  @spec has_css?(parent, locator) :: boolean()
+  @spec has_css?(parent, String.t()) :: boolean()
 
   def has_css?(parent, query, css) when is_binary(css) do
     parent
@@ -929,7 +928,7 @@ defmodule Wallaby.Browser do
   Searches for css that should not be on the page
   """
   @spec has_no_css?(parent, Query.t(), String.t()) :: boolean()
-  @spec has_no_css?(parent, locator) :: boolean()
+  @spec has_no_css?(parent, String.t()) :: boolean()
 
   def has_no_css?(parent, query, css) when is_binary(css) do
     parent


### PR DESCRIPTION
When using `Wallaby.Browser.has_text?/2`  and `Wallaby.Browser.assert_text/2` in a codebase, dialyzer throws warnings when you call these funcs with a `Wallaby.Session`, even though it is supported. Update the `@spec` declarations to use `parent` instead of `Element.t()`, so dialyzer can properly determine the usage is valid.

Additionally, in `Wallaby.Browser`, there is a `@type locator :: String.t()` def, which is only used 3x in the module, whereas `String.t()` is used 33x, sometimes in sibling `@spec` statements for the same multi-head function. Dropped `locator` and made the 3 instances `String.t()` instead.