### PR TITLE
Fix for typo in fill_in docs

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -173,7 +173,7 @@ defmodule Wallaby.Browser do
 
       page
       |> fill_in(Query.text_field("name"), with: "Chris")
-      |> fill_in(Query.css("#password_field", with: "secret42"))
+      |> fill_in(Query.css("#password_field"), with: "secret42")
 
   ### Note
 


### PR DESCRIPTION
Found this small typo in the docs.