### PR TITLE
Make assert_text pipeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main
 
+### Breaking
+
+- `Browser.assert_text/2` and `Browser.assert_text/3` now return the parent instead of `true` when the text was found.
+
 ## 0.27.0 (2020-12-4)
 
 ### Breaking

--- a/integration_test/cases/browser/assert_text_test.exs
+++ b/integration_test/cases/browser/assert_text_test.exs
@@ -13,7 +13,7 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
     refute has_text?(element, "rain")
   end
 
-  test "assert_text/2 waits for presence of text and and returns true if found", %{
+  test "assert_text/2 waits for presence of text and and returns the parent if found", %{
     session: session
   } do
     element =
@@ -21,7 +21,7 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
       |> visit("wait.html")
       |> find(Query.css("#container"))
 
-    assert assert_text(element, "main")
+    assert element == assert_text(element, "main")
   end
 
   test "assert_text/2 will raise an exception for text not found", %{session: session} do
@@ -39,6 +39,6 @@ defmodule Wallaby.Integration.Browser.AssertTextTest do
     session
     |> Browser.visit("wait.html")
 
-    assert Browser.assert_text(session, "main")
+    assert session == Browser.assert_text(session, "main")
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -764,7 +764,25 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Matches the Element's content with the provided text
+  Matches the parent's content with the provided text.
+
+  Returns a boolean that indicates if the text was found.
+
+  ## Examples
+
+  ```
+  session
+  |> visit("/")
+  |> has_text?("Login")
+  ```
+
+  Example providing query:
+
+  ```
+  session
+  |> visit("/")
+  |> has_text?(Query.css(".login-button"), "Login")
+  ```
   """
   @spec has_text?(parent, String.t()) :: boolean()
   @spec has_text?(parent, Query.t(), String.t()) :: boolean()
@@ -800,10 +818,29 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Matches the Element's content with the provided text and raises if not found
+  Matches the Element's content with the provided text and raises if not found.
+
+  Returns the given `parent` if the assertion is correct so that it is easily
+  pipeable.
+
+  ## Examples
+
+  ```
+  session
+  |> visit("/")
+  |> assert_text("Login")
+  ```
+
+  Example providing query:
+
+  ```
+  session
+  |> visit("/")
+  |> assert_text(Query.css(".login-button"), "Login")
+  ```
   """
-  @spec assert_text(parent, String.t()) :: boolean()
-  @spec assert_text(parent, Query.t(), String.t()) :: boolean()
+  @spec assert_text(parent, String.t()) :: parent
+  @spec assert_text(parent, Query.t(), String.t()) :: parent
   def assert_text(parent, query, text) when is_binary(text) do
     parent
     |> find(query)
@@ -811,7 +848,11 @@ defmodule Wallaby.Browser do
   end
 
   def assert_text(parent, text) when is_binary(text) do
-    has_text?(parent, text) || raise ExpectationNotMetError, "Text '#{text}' was not found."
+    if has_text?(parent, text) do
+      parent
+    else
+      raise ExpectationNotMetError, "Text '#{text}' was not found."
+    end
   end
 
   @doc """


### PR DESCRIPTION
This patch changes the `assert_text\2` and the `assert_text\3` methods to return the parent rather than `true` if the assertion passes.

This will allow easy piping of the method.

Closes https://github.com/elixir-wallaby/wallaby/issues/561