### PR TITLE
Fix Selenium uploads

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -202,8 +202,9 @@ defmodule Wallaby.Browser do
   Attaches a file to a file input. Input elements are looked up by id, label text,
   or name.
 
-  When dealing with a remote Selenium server, the file must be uploaded to the
-  remote Selenium server, else attaching a file fails.
+  When dealing with Selenium server (especially a remote instance), the file
+  must be uploaded to Selenium via `send_keys` recognizing a local file,
+  else attaching a file fails.
   """
   @spec attach_file(parent, Query.t(), path: String.t()) :: parent
   def attach_file(parent, query, path: path) do

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -211,7 +211,7 @@ defmodule Wallaby.Browser do
       true ->
         # local/remote selenium will only properly attach
         # & upload a local file with `send_keys`
-        send_keys(parent, query, [path])
+        send_keys(parent, query, List.wrap(path))
 
       false ->
         # retain existing chrome compatibility

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -201,12 +201,22 @@ defmodule Wallaby.Browser do
   @doc """
   Attaches a file to a file input. Input elements are looked up by id, label text,
   or name.
+
+  When dealing with a remote Selenium server, the file must be uploaded to the
+  remote Selenium server, else attaching a file fails.
   """
   @spec attach_file(parent, Query.t(), path: String.t()) :: parent
-
   def attach_file(parent, query, path: path) do
-    parent
-    |> set_value(query, :filename.absname(path))
+    case is_selenium?(parent) do
+      true ->
+        # local/remote selenium will only properly attach
+        # & upload a local file with `send_keys`
+        send_keys(parent, query, [path])
+
+      false ->
+        # retain existing chrome compatibility
+        set_value(parent, query, :filename.absname(path))
+    end
   end
 
   @doc """
@@ -1242,5 +1252,9 @@ defmodule Wallaby.Browser do
   @doc false
   def build_file_url(path) do
     "file://" <> (path |> Path.expand() |> URI.encode())
+  end
+
+  defp is_selenium?(parent) do
+    parent.driver == Wallaby.Selenium
   end
 end

--- a/lib/wallaby/helpers/key_codes.ex
+++ b/lib/wallaby/helpers/key_codes.ex
@@ -8,7 +8,6 @@ defmodule Wallaby.Helpers.KeyCodes do
   Encode a list of key codes to a usable json representation.
   """
   @spec json(list(atom)) :: String.t()
-
   def json(keys) when is_list(keys) do
     unicode =
       keys
@@ -17,6 +16,20 @@ defmodule Wallaby.Helpers.KeyCodes do
       |> Enum.join(",")
 
     "{\"value\": [#{unicode}]}"
+  end
+
+  @doc """
+  Ensures a list of keys are in binary
+  form to check for local files.
+  """
+  @spec chars(list() | binary()) :: [binary()]
+  def chars(keys) do
+    keys
+    |> List.wrap()
+    |> Enum.map(fn
+      a when is_atom(a) -> code(a)
+      s -> s
+    end)
   end
 
   defp split_strings(x) when is_binary(x), do: String.graphemes(x)

--- a/lib/wallaby/selenium.ex
+++ b/lib/wallaby/selenium.ex
@@ -295,9 +295,8 @@ defmodule Wallaby.Selenium do
   Simulates typing into an element.
 
   When sending keys to an element and `keys` is identified as
-  a local file, and we determine we are communicating with a
-  remote Selenium server, the local file is uploaded to the
-  remote Selenium server, providing a file path which is then
+  a local file, the local file is uploaded to the
+  Selenium server, returning a file path which is then
   set to the file input we are interacting with.
 
   We then call the `WebdriverClient.send_keys/2` to set the

--- a/lib/wallaby/selenium.ex
+++ b/lib/wallaby/selenium.ex
@@ -92,7 +92,7 @@ defmodule Wallaby.Selenium do
     with {:ok, response} <- WebdriverClient.create_session(base_url, capabilities) do
       id = response["sessionId"]
 
-      session = %Wallaby.Session{
+      session = %Session{
         session_url: base_url <> "session/#{id}",
         url: base_url <> "session/#{id}",
         id: id,
@@ -291,9 +291,34 @@ defmodule Wallaby.Selenium do
     WebdriverClient.execute_script_async(parent, script, arguments)
   end
 
-  @doc false
-  def send_keys(parent, keys) do
-    WebdriverClient.send_keys(parent, keys)
+  @doc """
+  Simulates typing into an element.
+
+  When sending keys to an element and `keys` is identified as
+  a local file, and we determine we are communicating with a
+  remote Selenium server, the local file is uploaded to the
+  remote Selenium server, providing a file path which is then
+  set to the file input we are interacting with.
+
+  We then call the `WebdriverClient.send_keys/2` to set the
+  remote file path as the input's value.
+  """
+  @spec send_keys(Session.t() | Element.t(), list()) :: {:ok, any}
+  def send_keys(%Session{} = session, keys), do: WebdriverClient.send_keys(session, keys)
+
+  def send_keys(%Element{} = element, keys) do
+    maybe_file = IO.iodata_to_binary(keys)
+
+    keys =
+      case is_local_file?(keys) do
+        true ->
+          upload_file(element, maybe_file)
+
+        false ->
+          keys
+      end
+
+    WebdriverClient.send_keys(element, keys)
   end
 
   @doc false
@@ -305,5 +330,55 @@ defmodule Wallaby.Selenium do
         args: ["-headless"]
       }
     }
+  end
+
+  # Create a zip file containing our local file
+  defp create_zipfile(zipfile, filename) do
+    {:ok, ^zipfile} =
+      :zip.create(
+        zipfile,
+        [String.to_charlist(Path.basename(filename))],
+        cwd: String.to_charlist(Path.dirname(filename))
+      )
+
+    zipfile
+  end
+
+  # Base64 encode the zipfile for transfer to remote Selenium
+  defp encode_zipfile(zipfile) do
+    File.open!(zipfile, [:read, :raw], fn f ->
+      f
+      |> IO.binread(:all)
+      |> Base.encode64()
+    end)
+  end
+
+  defp is_local_file?(file) do
+    File.exists?(file)
+  end
+
+  # Makes an uploadable file for JSONWireProtocol
+  defp make_file(filename) do
+    System.tmp_dir!()
+    |> Path.join("#{random_filename()}.zip")
+    |> String.to_charlist()
+    |> create_zipfile(filename)
+    |> encode_zipfile()
+  end
+
+  # Generate a random filename
+  defp random_filename do
+    Base.encode32(:crypto.strong_rand_bytes(20))
+  end
+
+  # Uploads a local file to remote Selenium server
+  # Returns the remote file's uploaded location
+  defp upload_file(element, filename) do
+    zip64 = make_file(filename)
+    endpoint = element.session_url <> "/file"
+
+    with {:ok, response} <- Wallaby.HTTPClient.request(:post, endpoint, %{file: zip64}) do
+      [Map.fetch!(response, "value")]
+    end
   end
 end

--- a/lib/wallaby/webdriver_client.ex
+++ b/lib/wallaby/webdriver_client.ex
@@ -437,7 +437,7 @@ defmodule Wallaby.WebdriverClient do
   @doc """
   Sends a list of key strokes to active element.
   """
-  @spec send_keys(Session.t(), [String.t() | atom]) :: {:ok, nil}
+  @spec send_keys(parent(), [String.t() | atom]) :: {:ok, any}
   def send_keys(%Session{} = session, keys) when is_list(keys) do
     with {:ok, resp} <-
            request(:post, "#{session.session_url}/keys", KeyCodes.json(keys), encode_json: false),
@@ -445,9 +445,9 @@ defmodule Wallaby.WebdriverClient do
          do: {:ok, value}
   end
 
-  def send_keys(parent, keys) when is_list(keys) do
+  def send_keys(%Element{} = element, keys) when is_list(keys) do
     with {:ok, resp} <-
-           request(:post, "#{parent.url}/value", KeyCodes.json(keys), encode_json: false),
+           request(:post, "#{element.url}/value", KeyCodes.json(keys), encode_json: false),
          {:ok, value} <- Map.fetch(resp, "value"),
          do: {:ok, value}
   end

--- a/test/wallaby/helpers/key_codes_test.exs
+++ b/test/wallaby/helpers/key_codes_test.exs
@@ -3,12 +3,25 @@ defmodule Wallaby.Helpers.KeyCodesTest do
 
   import Wallaby.Helpers.KeyCodes
 
-  test "encoding unicode values" do
+  test "encoding unicode values as JSON" do
     assert json([:enter]) == "{\"value\": [\"\\uE007\"]}"
     assert json([:shift, :enter]) == "{\"value\": [\"\\uE008\",\"\\uE007\"]}"
   end
 
-  test "encoding values with strings" do
+  test "encoding values with strings as JSON" do
     assert json(["te", :enter]) == "{\"value\": [\"t\",\"e\",\"\\uE007\"]}"
+  end
+
+  test "ensuring chars returns list of strings" do
+    assert chars([:enter]) == ["\\uE007"]
+    assert chars(:enter) == ["\\uE007"]
+    assert chars([:shift, :enter]) == ["\\uE008", "\\uE007"]
+    assert chars(["John", :tab, "Smith"]) == ["John", "\\uE004", "Smith"]
+  end
+
+  test "ensuring chars returns file paths as file paths" do
+    assert chars("/some/path/to/foo.txt") == ["/some/path/to/foo.txt"]
+    files = ["/path/to/foo.txt", "/path/to/bar.txt"]
+    assert chars(files) == files
   end
 end


### PR DESCRIPTION
Currently, Wallaby's `Browser.attach_file` uses `set_value` to set a file path as the value of an file input.

Unfortunately, this does not actually attach a file when using Selenium, and submitting a form when using this function results in errors for invalid multipart payloads. This problem is more pronounced when using a remote Selenium instance, as a file input can only attach a file that is available on the local machine.

Selenium's standalone server provides a means of handling this that is implemented in other libraries (e.g., [the official Python implementation](https://github.com/SeleniumHQ/selenium/blob/941dc9c6b2e2aa4f701c1b72be8de03d4b7e996a/py/selenium/webdriver/remote/webelement.py#L511)).

The basic outline of how this is supposed to work with Selenium servers is as follows:

1. Instead of calling `set_value` on a file input, you should call `send_keys` on the file input with the local file path
2. `send_keys` should detect if the `keys` supplied are actually a local file path
3. When a local file is detected:
  a. create a zip file containing the local file
  b. base64 encode the zip file from step 3a
  c. upload encoded zip from 3b to Selenium's `<session_id>/file` endpoint
4. step c will return the path (local to Selenium) where the file was uploaded and attached to the active Selenium session
5. Call `send_keys` on the file input, this time sending the local-to-Selenium path as the value for the file input

Upon submitting the form, your local file will have been successfully uploaded to Selenium and attached to the form for proper submission.

This PR implements correct and successful file uploads for Selenium in `Browser.attach_file`—it detects if the `driver` is Selenium, and follows the path above, otherwise, falls back to `set_value` for maintaining Chrome compatibility (which seems to be fine with `set_value` and properly uploads a file *locally* (but I'm unclear on how you'd do that remotely and verify)).

**NOTE:** All existing tests pass, and much of this functionality relies on modifying the `Selenium` module, since it is Selenium-specific functionality. However, I'm not sure how best to add tests for the remote Selenium server case, as that requires an actual remote Selenium server instance running. This doesn't change any test behavior as it is written, and verifying this with a successful upload would require more in the Wallaby project to process an uploaded file (which is maybe why this hasn't been caught before?).