### PR TITLE
Ensure all sessions are closed after test suite finished.

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,6 @@
 # Used for ignoring dialyzer errors
 # See: https://github.com/jeremyjh/dialyxir#elixir-term-format
 [
-  ~r"Function Mix.env/0 does not exist."
+  ~r"Function Mix.env/0 does not exist.",
+  ~r"Function ExUnit.after_suite/1 does not exist."
 ]

--- a/.github/workflows/chromedriver.yml
+++ b/.github/workflows/chromedriver.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
+        elixir: [1.8.x, 1.9.x, 1.10.x, 1.11.x]
       fail-fast: false
 
     env:

--- a/.github/workflows/inch.yml
+++ b/.github/workflows/inch.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-elixir@v1.0.0
       with:
         otp-version: 21.x
-        elixir-version: 1.7.x
+        elixir-version: 1.8.x
     - uses: actions/cache@v1
       id: cache
       with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
+        elixir: [1.8.x, 1.9.x, 1.10.x, 1.11.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
+        elixir: [1.8.x, 1.9.x, 1.10.x, 1.11.x]
       fail-fast: false
 
     env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp: [21.x]
-        elixir: [1.7.x, 1.8.x, 1.9.x, 1.10.x, 1.11.x]
+        elixir: [1.8.x, 1.9.x, 1.10.x, 1.11.x]
       fail-fast: false
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Master
 
+### Breaking
+
+- Increases minimum Elixir version to 1.8
+
+### Fixes
+
 - Correctly remove stopped sessions from the internal store. [#558](https://github.com/elixir-wallaby/wallaby/pull/558)
+- Ensures all sessions are closed after the test suite is over.
 
 ## 0.26.2 (2020-06-19)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Read on to see what else Wallaby can do or check out the [Official Documentation
 
 ### Requirements
 
-Wallaby requires Elixir 1.7+ and OTP 21+.
+Wallaby requires Elixir 1.8+ and OTP 21+.
 
 ### Installation
 

--- a/integration_test/chrome/starting_sessions_test.exs
+++ b/integration_test/chrome/starting_sessions_test.exs
@@ -12,7 +12,11 @@ defmodule Wallaby.Integration.Chrome.StartingSessionsTest do
 
   @moduletag :capture_log
 
-  setup [:restart_wallaby_on_exit!, :stop_wallaby, :create_test_workspace]
+  setup [:restart_wallaby_on_exit!, :stop_wallaby]
+
+  setup do
+    [workspace_path: mkdir!()]
+  end
 
   test "works when chromedriver starts immediately", %{workspace_path: workspace_path} do
     {:ok, chromedriver_path} = Chrome.find_chromedriver_executable()

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -548,21 +548,16 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Clicks at the current mouse cursor position.
+  Clicks the mouse on the element returned by the query or at the current mouse cursor position.
   """
-  @spec click(parent, atom) :: parent
-
+  @spec click(parent, :left | :middle | :right) :: parent
+  @spec click(parent, Query.t()) :: parent
   def click(parent, button) when button in [:left, :middle, :right] do
     case parent.driver.click(parent, button) do
       {:ok, _} ->
         parent
     end
   end
-
-  @doc """
-  Clicks an element.
-  """
-  @spec click(parent, Query.t()) :: parent
 
   def click(parent, query) do
     parent
@@ -573,7 +568,6 @@ defmodule Wallaby.Browser do
   Double-clicks left mouse button at the current mouse coordinates.
   """
   @spec double_click(parent) :: parent
-
   def double_click(parent) do
     case parent.driver.double_click(parent) do
       {:ok, _} ->
@@ -585,7 +579,6 @@ defmodule Wallaby.Browser do
    Clicks and holds the given mouse button at the current mouse coordinates.
   """
   @spec button_down(parent, atom) :: parent
-
   def button_down(parent, button \\ :left) when button in [:left, :middle, :right] do
     case parent.driver.button_down(parent, button) do
       {:ok, _} ->
@@ -597,7 +590,6 @@ defmodule Wallaby.Browser do
    Releases given previously held mouse button.
   """
   @spec button_up(parent, atom) :: parent
-
   def button_up(parent, button \\ :left) when button in [:left, :middle, :right] do
     case parent.driver.button_up(parent, button) do
       {:ok, _} ->
@@ -609,7 +601,6 @@ defmodule Wallaby.Browser do
   Hovers over an element.
   """
   @spec hover(parent, Query.t()) :: parent
-
   def hover(parent, query) do
     parent
     |> find(query, &Element.hover/1)
@@ -619,7 +610,6 @@ defmodule Wallaby.Browser do
   Moves mouse by an offset relative to current cursor position.
   """
   @spec move_mouse_by(parent, integer, integer) :: parent
-
   def move_mouse_by(parent, x_offset, y_offset) do
     case parent.driver.move_mouse_by(parent, x_offset, y_offset) do
       {:ok, _} ->
@@ -634,7 +624,6 @@ defmodule Wallaby.Browser do
   """
   @spec text(parent) :: String.t()
   @spec text(parent, Query.t()) :: String.t()
-
   def text(parent, query) do
     parent
     |> find(query)
@@ -651,7 +640,6 @@ defmodule Wallaby.Browser do
   Gets the value of the elements attribute.
   """
   @spec attr(parent, Query.t(), String.t()) :: String.t() | nil
-
   def attr(parent, query, name) do
     parent
     |> find(query)
@@ -662,7 +650,6 @@ defmodule Wallaby.Browser do
   Checks if the element has been selected. Alias for checked?(element)
   """
   @spec selected?(parent, Query.t()) :: boolean()
-
   def selected?(parent, query) do
     parent
     |> find(query)
@@ -673,7 +660,6 @@ defmodule Wallaby.Browser do
   Checks if the element is visible on the page
   """
   @spec visible?(parent, Query.t()) :: boolean()
-
   def visible?(parent, query) do
     parent
     |> has?(query)
@@ -694,7 +680,6 @@ defmodule Wallaby.Browser do
   @spec find(parent, Query.t(), (Element.t() -> any())) :: parent
   @spec find(parent, Query.t()) :: Element.t() | [Element.t()]
   @spec find(parent, String.t()) :: Element.t() | [Element.t()]
-
   def find(parent, %Query{} = query, callback) when is_function(callback) do
     results = find(parent, query)
     callback.(results)
@@ -729,7 +714,6 @@ defmodule Wallaby.Browser do
   `find(session, css("element", count: nil, minimum: 0))`.
   """
   @spec all(parent, Query.t()) :: [Element.t()]
-
   def all(parent, %Query{} = query) do
     find(
       parent,
@@ -742,7 +726,6 @@ defmodule Wallaby.Browser do
   types of matchers.
   """
   @spec has?(parent, Query.t()) :: boolean()
-
   def has?(parent, query) do
     case execute_query(parent, query) do
       {:ok, _} -> true
@@ -755,7 +738,6 @@ defmodule Wallaby.Browser do
   """
   @spec has_value?(parent, Query.t(), any()) :: boolean()
   @spec has_value?(Element.t(), any()) :: boolean()
-
   def has_value?(parent, query, value) do
     parent
     |> find(query)
@@ -786,7 +768,6 @@ defmodule Wallaby.Browser do
   """
   @spec has_text?(parent, String.t()) :: boolean()
   @spec has_text?(parent, Query.t(), String.t()) :: boolean()
-
   def has_text?(parent, query, text) do
     parent
     |> find(query)
@@ -823,7 +804,6 @@ defmodule Wallaby.Browser do
   """
   @spec assert_text(parent, String.t()) :: boolean()
   @spec assert_text(parent, Query.t(), String.t()) :: boolean()
-
   def assert_text(parent, query, text) when is_binary(text) do
     parent
     |> find(query)
@@ -889,7 +869,6 @@ defmodule Wallaby.Browser do
       |> visit("/")
       |> refute_has(Query.css(".secret-admin-content"))
   """
-
   defmacro refute_has(parent, query) do
     quote do
       parent = unquote(parent)
@@ -911,7 +890,6 @@ defmodule Wallaby.Browser do
   """
   @spec has_css?(parent, Query.t(), String.t()) :: boolean()
   @spec has_css?(parent, String.t()) :: boolean()
-
   def has_css?(parent, query, css) when is_binary(css) do
     parent
     |> find(query)
@@ -929,7 +907,6 @@ defmodule Wallaby.Browser do
   """
   @spec has_no_css?(parent, Query.t(), String.t()) :: boolean()
   @spec has_no_css?(parent, String.t()) :: boolean()
-
   def has_no_css?(parent, query, css) when is_binary(css) do
     parent
     |> find(query)
@@ -947,7 +924,6 @@ defmodule Wallaby.Browser do
   Absolute paths do not use the base_url.
   """
   @spec visit(session, String.t()) :: session
-
   def visit(%Session{driver: driver} = session, path) do
     uri = URI.parse(path)
 

--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -142,7 +142,7 @@ defmodule Wallaby.Chrome do
   end
 
   @doc false
-  def init(:ok) do
+  def init(_) do
     children = [
       Wallaby.Driver.LogStore,
       Wallaby.Chrome.Chromedriver

--- a/lib/wallaby/selenium.ex
+++ b/lib/wallaby/selenium.ex
@@ -74,8 +74,8 @@ defmodule Wallaby.Selenium do
   end
 
   @doc false
-  def init(:ok) do
-    supervise([], strategy: :one_for_one)
+  def init(_) do
+    Supervisor.init([], strategy: :one_for_one)
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Wallaby.Mixfile do
     [
       app: :wallaby,
       version: @version,
-      elixir: "~> 1.7",
+      elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/support/test_workspace.ex
+++ b/test/support/test_workspace.ex
@@ -6,13 +6,6 @@ defmodule Wallaby.TestSupport.TestWorkspace do
 
   import ExUnit.Callbacks, only: [on_exit: 1]
 
-  @deprecated "Use mkdir!/0 inside test instead"
-  def create_test_workspace(_) do
-    workspace_path = mkdir!()
-
-    [workspace_path: workspace_path]
-  end
-
   @doc """
   Create a directory that will be removed after the test exits.
 


### PR DESCRIPTION
Ensure all sessions are closed on exit

If you were running a test with many sessions, and it was either the last test to run or the only test to run, then there was the chance that the SessionStore would exit before we could ask the webdriver to close the sessions.

While the webdriver would successfully die, this would leave zombie browser processes lingering, tormenting the living.

Here, we use the after_suite callback from ExUnit to ensure that these sessions get closed before ExUnit kills Wallaby.

Unfortunately this was introduced in Elixir 1.8, so we now have to raise the minimum Elixir version to 1.8, which I think is reasonable, considering the latest version is 1.11.

Fixes #554 
Fixes #544 
