### PR TITLE
fixes the DependencyError message  in chrome.ex

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -184,7 +184,7 @@ defmodule Wallaby.Chrome do
           DependencyError.exception("""
           Wallaby can't find chromedriver. Make sure you have chromedriver installed
           and included in your path.
-          You can also provide a path using `config :wallaby, chromedriver: <path>`.
+          You can also provide a path using `config :wallaby, :chromedriver, path: <path>`.
           """)
 
         {:error, exception}


### PR DESCRIPTION
Setting the `chromedriver` outside the projects doesn't work even if I follow the docs.

```elixir
** (Mix) Could not start application wallaby: exited in: Wallaby.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Keyword.get/3
            (elixir 1.10.4) lib/keyword.ex:201: Keyword.get("/media/alexandrubagu/devel/utils/chromedriver", :path, "chromedriver")
            (wallaby 0.28.0) lib/wallaby/chrome.ex:174: Wallaby.Chrome.find_chromedriver_executable/0
            (wallaby 0.28.0) lib/wallaby/chrome.ex:157: Wallaby.Chrome.validate/0
            (wallaby 0.28.0) lib/wallaby.ex:31: Wallaby.start/2
```

Solution: 
 - change: ```config :wallaby, chromedriver: "/media/alexandrubagu/devel/utils/chromedriver"```
 - to: ```config :wallaby, :chromedriver, path: "/media/alexandrubagu/devel/utils/chromedriver"```



