### PR TITLE
Put metadata into useragent for Firefox

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.11.2-otp-21
-erlang 21.3
+erlang 23.3.4.4

--- a/integration_test/selenium/selenium_capabilities_test.exs
+++ b/integration_test/selenium/selenium_capabilities_test.exs
@@ -1,0 +1,68 @@
+defmodule Wallaby.Integration.SeleniumCapabilitiesTest do
+  use ExUnit.Case, async: false
+  use Wallaby.DSL
+
+  import Wallaby.SettingsTestHelpers
+
+  alias Wallaby.Integration.SessionCase
+  alias Wallaby.WebdriverClient
+
+  setup do
+    ensure_setting_is_reset(:wallaby, :selenium)
+  end
+
+  describe "capabilities" do
+    test "reads default capabilities" do
+      expected_capabilities = %{
+        javascriptEnabled: true,
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"],
+          prefs: %{
+            "general.useragent.override" =>
+              "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+          }
+        }
+      }
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+
+    test "reads capabilities from application config" do
+      expected_capabilities = %{
+        browserName: "firefox",
+        "moz:firefoxOptions": %{
+          args: ["-headless"]
+        }
+      }
+
+      Application.put_env(:wallaby, :selenium, capabilities: expected_capabilities)
+
+      create_session_fn = fn url, capabilities ->
+        assert capabilities == expected_capabilities
+
+        WebdriverClient.create_session(url, capabilities)
+      end
+
+      {:ok, session} = SessionCase.start_test_session(create_session_fn: create_session_fn)
+
+      session
+      |> visit("page_1.html")
+      |> assert_has(Query.text("Page 1"))
+
+      assert :ok = Wallaby.end_session(session)
+    end
+  end
+end

--- a/test/wallaby/selenium/start_session_config_test.exs
+++ b/test/wallaby/selenium/start_session_config_test.exs
@@ -24,7 +24,13 @@ defmodule Wallaby.Selenium.StartSessionConfigTest do
                "desiredCapabilities" => %{
                  "browserName" => "firefox",
                  "javascriptEnabled" => true,
-                 "moz:firefoxOptions" => %{"args" => ["-headless"]}
+                 "moz:firefoxOptions" => %{
+                   "args" => ["-headless"],
+                   "prefs" => %{
+                     "general.useragent.override" =>
+                       "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+                   }
+                 }
                }
              }
 


### PR DESCRIPTION
This enables async tests while using the default selenium configuration.
