### PR TITLE
has_css? should return a boolean. Fix for Issue: #585.

### DIFF
--- a/integration_test/cases/browser/assert_css_test.exs
+++ b/integration_test/cases/browser/assert_css_test.exs
@@ -9,7 +9,31 @@ defmodule Wallaby.Integration.Browser.AssertCssTest do
     assert has_css?(page, ".user")
   end
 
-  test "has_no_css/2 checks is the css is not on the page", %{session: session} do
+  test "has_css/2 returns false if the css is not on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    refute has_css?(page, ".something_else")
+  end
+
+  test "has_css/3 returns true if the css is on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    assert has_css?(page, Query.css(".dashboard"), ".users")
+  end
+
+  test "has_css/3 returns false if the css is not on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    refute has_css?(page, Query.css(".dashboard"), ".something_else")
+  end
+
+  test "has_no_css/2 returns true if the css is not on the page", %{session: session} do
     page =
       session
       |> visit("nesting.html")
@@ -17,9 +41,27 @@ defmodule Wallaby.Integration.Browser.AssertCssTest do
     assert has_no_css?(page, ".something_else")
   end
 
-  test "has_no_css/2 raises error if the css is found", %{session: session} do
-    refute session
-           |> visit("nesting.html")
-           |> has_no_css?(".user")
+  test "has_no_css/2 returns false if the css is on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    refute has_no_css?(page, ".user")
+  end
+
+  test "has_no_css/3 returns false if the css is on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    refute has_no_css?(page, Query.css(".dashboard"), ".user")
+  end
+
+  test "has_no_css/3 returns true if the css is not on the page", %{session: session} do
+    page =
+      session
+      |> visit("nesting.html")
+
+    assert has_no_css?(page, Query.css(".dashboard"), ".something_else")
   end
 end

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1017,8 +1017,7 @@ defmodule Wallaby.Browser do
 
   def has_css?(parent, css) when is_binary(css) do
     parent
-    |> find(Query.css(css, count: :any))
-    |> Enum.any?()
+    |> has?(Query.css(css, count: :any))
   end
 
   @doc """


### PR DESCRIPTION
@adkron posted an issue: https://github.com/elixir-wallaby/wallaby/issues/585 that the `has_css?/2` function was raising an exception.

This is my first PR in the project, and I'm new to open source 🙏 Please let me know if I'm breaking any rules or need to adjust anything!

the `has_css?/2` method was using `find/1` instead of `has?/1` causing it to throw an error instead of returning a boolean.

I've added testing and made test names consistent for has_css?/2, has_css/3, has_no_css?/2, and has_no_css/3 to make sure all work as expected.