### PR TITLE
Improve find/2 and find/3 specs and doc

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -922,26 +922,28 @@ defmodule Wallaby.Browser do
   end
 
   @doc """
-  Finds a specific DOM element on the page based on a CSS selector. Blocks until
-  it either finds the element or until the max time is reached. By default only
-  1 element is expected to match the query. If more elements are present then a
-  count can be specified. Use `:any` to allow any number of elements to be present.
-  By default only elements that are visible on the page are returned.
+  Finds one or more specific DOM element(s) on the page based on a CSS selector,
+  and returns them.
+
+  Blocks until it either finds the element(s) or until the max time is reached.
+  By default only 1 element is expected to match the query. If more elements
+  are present then a count can be specified. Use `count: :any` to allow any
+  number of elements to be present.
+
+  By default only elements that would be visible to a real user on the page are
+  returned.
 
   Selections can be scoped by providing a Element as the locator for the query.
 
-  By default finders only work with elements that would be visible to a real
-  user.
-  """
-  @spec find(parent, Query.t(), (Element.t() -> any())) :: parent
-  @spec find(parent, Query.t()) :: Element.t() | [Element.t()]
-  @spec find(parent, String.t()) :: Element.t() | [Element.t()]
-  def find(parent, %Query{} = query, callback) when is_function(callback) do
-    results = find(parent, query)
-    callback.(results)
-    parent
-  end
+  ## Examples
 
+      session
+      |> find(Query.css("#login-button"))
+      |> assert_text("Login")
+
+      find(session, Query.css(".login-button", count: 2, text: "Login"))
+  """
+  @spec find(parent, Query.t()) :: Element.t() | [Element.t()]
   def find(parent, %Query{} = query) do
     case execute_query(parent, query) do
       {:ok, query} ->
@@ -962,6 +964,16 @@ defmodule Wallaby.Browser do
       {:error, e} ->
         raise Wallaby.QueryError, ErrorMessage.message(query, e)
     end
+  end
+
+  @doc """
+  Same as `find/2` but takes a callback function as its last argument.
+  """
+  @spec find(parent, Query.t(), (Element.t() -> any())) :: parent
+  def find(parent, %Query{} = query, callback) when is_function(callback) do
+    results = find(parent, query)
+    callback.(results)
+    parent
   end
 
   @doc """


### PR DESCRIPTION
Hello! I've been using `Browser.find/2` and `Browser.find/3` a lot lately and recently noticed that the `/2` arity actually:
1. does not take a string as its second argument as far as I am aware, only a `Query.css`
2. returns either one element or a list of found elements - which has been very useful to me lately - but the doc does not mention it explicitly

So I thought I would remove the string `@spec`, and rework the documentation a bit to make it clearer. What do you think? 

And thanks for maintaining Wallaby! :)