### PR TITLE
Remove default for `count` when given an `at` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Main
 
 - Fix `refute_has` when passed a query with an invalid selector.
+- Specifying `at` now removes the default `count` of 1 (#641)
 
 ## v0.29.1 (2021-09-22)
 

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -135,8 +135,8 @@ defmodule Wallaby.Query.ErrorMessage do
   @spec method(Query.t()) :: String.t()
   @spec method({atom(), boolean()}) :: String.t()
 
-  def method(%Query{conditions: conditions} = query) do
-    method(query.method, conditions[:count] != 1)
+  def method(%Query{} = query) do
+    method(query.method, Query.count(query) != 1)
   end
 
   def method(_), do: "element"
@@ -246,10 +246,11 @@ defmodule Wallaby.Query.ErrorMessage do
 
   defp expected_count(query) do
     conditions = query.conditions
+    count = Query.count(query)
 
     cond do
-      conditions[:count] ->
-        "#{conditions[:count]}"
+      count ->
+        "#{count}"
 
       conditions[:minimum] && Enum.count(query.result) < conditions[:minimum] ->
         "at least #{conditions[:minimum]}"

--- a/test/wallaby/query_test.exs
+++ b/test/wallaby/query_test.exs
@@ -6,24 +6,24 @@ defmodule Wallaby.QueryTest do
 
   describe "default count" do
     test "the count defaults to 1 if no count is specified" do
-      conditions = Query.css(nil).conditions
-      assert conditions[:count] == 1
+      query = Query.css(nil)
+      assert Query.count(query) == 1
 
-      conditions = Query.css(nil, count: 1).conditions
-      assert conditions[:count] == 1
+      query = Query.css(nil, count: 1)
+      assert Query.count(query) == 1
 
-      conditions = Query.css(nil, count: 3).conditions
-      assert conditions[:count] == 3
+      query = Query.css(nil, count: 3)
+      assert Query.count(query) == 3
     end
 
     test "the count is nil if a minimum or maximum is set" do
-      conditions = Query.css(nil, minimum: 1).conditions
-      assert conditions[:count] == nil
-      assert conditions[:minimum] == 1
+      query = Query.css(nil, minimum: 1)
+      assert Query.count(query) == nil
+      assert query.conditions[:minimum] == 1
 
-      conditions = Query.css(nil, maximum: 1).conditions
-      assert conditions[:count] == nil
-      assert conditions[:maximum] == 1
+      query = Query.css(nil, maximum: 1)
+      assert Query.count(query) == nil
+      assert query.conditions[:maximum] == 1
     end
   end
 
@@ -169,12 +169,38 @@ defmodule Wallaby.QueryTest do
   end
 
   describe "at/2" do
-    test "sets at option in a query" do
+    test "sets at option in a query and count defaults to nil" do
       query =
         Query.css(".test")
         |> Query.at(3)
 
       assert Query.at_number(query) == 3
+      assert Query.count(query) == nil
+    end
+
+    test "maintains count if it was specified" do
+      query =
+        Query.css(".test", count: 1)
+        |> Query.at(0)
+
+      assert Query.at_number(query) == 0
+      assert Query.count(query) == 1
+    end
+  end
+
+  describe "at option" do
+    test "sets at option in a query and count defaults to nil" do
+      query = Query.css(".test", at: 3)
+
+      assert Query.at_number(query) == 3
+      assert Query.count(query) == nil
+    end
+
+    test "maintains count if it was specified" do
+      query = Query.css(".test", count: 1, at: 0)
+
+      assert Query.at_number(query) == 0
+      assert Query.count(query) == 1
     end
   end
 end


### PR DESCRIPTION
This is achieved with a lazy default for `conditions[:count]`.
The function `Query.count/1` must now be used to get the effective count condition.

Alternative would have been to continue setting `count` to a
non `nil` default when conditions are first built. This has the inconvenient
of not being to distinguish a count set by default from an explicit one (i.e.
`Query.css(".x") |> Query.at(0)` from `Query.css(".x", count: 1) |> Query.at(0)`)

[Fixes #641]
To avoid conflicts, this includes #636 and #638