### PR TITLE
Restore elixir version to a modern version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.2
+elixir 1.11.2-otp-21
 erlang 23.3.4.4

--- a/integration_test/cases/browser/tap_test.exs
+++ b/integration_test/cases/browser/tap_test.exs
@@ -12,7 +12,7 @@ defmodule Wallaby.Integration.Browser.TapTest do
       assert visible?(page, Query.text("Start", count: 0))
       assert visible?(page, Query.text("End", count: 0))
 
-      tap(page, Query.text("Touch me!"))
+      Browser.tap(page, Query.text("Touch me!"))
 
       assert visible?(page, Query.text("Start"))
       assert visible?(page, Query.text("End"))


### PR DESCRIPTION
I'd like to use a modern version locally, for error messages, speed, etc.

Could we consider git-ignoring and removing `.tool-versions` altogether?