### PR TITLE
Fix failures related to `at` queries.

### DIFF
--- a/integration_test/cases/browser/assert_refute_has_test.exs
+++ b/integration_test/cases/browser/assert_refute_has_test.exs
@@ -36,7 +36,7 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
 
     test "mentions the count of found vs. expected index", %{session: session} do
       assert_raise ExpectationNotMetError,
-                   ~r/Expected.*and take index 7 but only 6 visible elements were found/i,
+                   ~r/Expected.*and return element at index 7 but only 6 visible elements were found/i,
                    fn ->
                      session
                      |> visit("nesting.html")

--- a/integration_test/cases/browser/assert_refute_has_test.exs
+++ b/integration_test/cases/browser/assert_refute_has_test.exs
@@ -6,6 +6,8 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
   @found_query Query.css(".user", count: :any)
   @not_found_query Query.css(".something-else")
   @wrong_exact_found_query Query.css(".user", count: 5)
+  @at_query Query.css(".user", at: 3)
+  @wrong_at_query Query.css(".user", at: 7)
   describe "assert_has/2" do
     test "passes if the query is present on the page", %{session: session} do
       return =
@@ -30,6 +32,25 @@ defmodule Wallaby.Integration.Browser.AssertRefuteHasTest do
         |> visit("nesting.html")
         |> assert_has(@wrong_exact_found_query)
       end
+    end
+
+    test "mentions the count of found vs. expected index", %{session: session} do
+      assert_raise ExpectationNotMetError,
+                   ~r/Expected.*and take index 7 but only 6 visible elements were found/i,
+                   fn ->
+                     session
+                     |> visit("nesting.html")
+                     |> assert_has(@wrong_at_query)
+                   end
+    end
+
+    test "passes if `at` element exists", %{session: session} do
+      return =
+        session
+        |> visit("nesting.html")
+        |> assert_has(@at_query)
+
+      assert %Wallaby.Session{} = return
     end
   end
 

--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -137,7 +137,7 @@ defmodule Wallaby.Integration.QueryTest do
   end
 
   test "queries can not select an element off the end of the list", %{session: session} do
-    assert_raise Wallaby.QueryError, ~r/and return element at index 5 but only 5 visible/, fn ->
+    assert_raise Wallaby.QueryError, ~r/and return element at index 5, but only 5 visible/, fn ->
       session
       |> Browser.visit("/page_1.html")
       |> Browser.find(Query.css(".user", at: 5))

--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -137,7 +137,7 @@ defmodule Wallaby.Integration.QueryTest do
   end
 
   test "queries can not select an element off the end of the list", %{session: session} do
-    assert_raise Wallaby.QueryError, ~r/and take index 5 but only 5 visible/, fn ->
+    assert_raise Wallaby.QueryError, ~r/and return element at index 5 but only 5 visible/, fn ->
       session
       |> Browser.visit("/page_1.html")
       |> Browser.find(Query.css(".user", at: 5))

--- a/integration_test/cases/query_test.exs
+++ b/integration_test/cases/query_test.exs
@@ -137,10 +137,10 @@ defmodule Wallaby.Integration.QueryTest do
   end
 
   test "queries can not select an element off the end of the list", %{session: session} do
-    assert_raise Wallaby.QueryError, fn ->
+    assert_raise Wallaby.QueryError, ~r/and take index 5 but only 5 visible/, fn ->
       session
       |> Browser.visit("/page_1.html")
-      |> Browser.find(Query.css(".user", count: 5, at: 5))
+      |> Browser.find(Query.css(".user", at: 5))
     end
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1175,9 +1175,9 @@ defmodule Wallaby.Browser do
               raise ExpectationNotMetError,
                     Query.ErrorMessage.message(query, :not_found)
 
-            {:error, :invalid_selector} ->
+            {:error, e} ->
               raise Wallaby.QueryError,
-                    Query.ErrorMessage.message(query, :invalid_selector)
+                    Query.ErrorMessage.message(query, e)
 
             _ ->
               raise Wallaby.ExpectationNotMetError,
@@ -1466,11 +1466,11 @@ defmodule Wallaby.Browser do
       {:all, _} ->
         {:ok, elements}
 
-      {n, count} when n >= 0 and n < count ->
+      {n, count} when n < count ->
         {:ok, [Enum.at(elements, n)]}
 
       {_, _} ->
-        {:error, {:at_number, query}}
+        {:error, {:not_found, elements}}
     end
   end
 

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -415,6 +415,9 @@ defmodule Wallaby.Query do
       Query.visible?(query) != true && Query.inner_text(query) ->
         {:error, :cannot_set_text_with_invisible_elements}
 
+      at_number(query) != :all && (at_number(query) < 0 || not is_integer(at_number(query))) ->
+        {:error, {:invalid_at_number, at_number(query)}}
+
       true ->
         {:ok, query}
     end

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -107,7 +107,7 @@ defmodule Wallaby.Query.ErrorMessage do
     """
     #{expected_count(query)} #{visibility_and_selection(query)} #{method(query)} #{
       selector(query)
-    }#{with_index(Query.at_number(query))} but #{result_adverb(query)}#{
+    }#{with_index(Query.at_number(query))}, but #{result_adverb(query)}#{
       result_count(query.result)
     } #{visibility_and_selection(query)} #{short_method(query.method, Enum.count(query.result))} #{
       result_expectation(query.result)

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -129,7 +129,7 @@ defmodule Wallaby.Query.ErrorMessage do
   end
 
   defp with_index(:all), do: nil
-  defp with_index(at), do: " and take index #{at}"
+  defp with_index(at), do: " and return element at index #{at}"
 
   @doc """
   Extracts the selector method from the selector and converts it into a human

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -99,7 +99,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find some visible elements that matched the css '.test'
-               and take index 2 but only 2 visible elements were found.
+               and return element at index 2 but only 2 visible elements were found.
                """)
     end
 
@@ -113,7 +113,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find some visible checkboxes 'test'
-               and take index 3 but only 2 visible checkboxes were found.
+               and return element at index 3 but only 2 visible checkboxes were found.
                """)
     end
 

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -14,7 +14,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element that matched the css '.test' but 3 visible
+               Expected to find 1 visible element that matched the css '.test', but 3 visible
                elements were found.
                """)
     end
@@ -28,7 +28,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 0 visible elements that matched the css '.test' but 3 visible
+               Expected to find 0 visible elements that matched the css '.test', but 3 visible
                elements were found.
                """)
     end
@@ -42,7 +42,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element that matched the css '.test' but 0 visible
+               Expected to find 1 visible element that matched the css '.test', but 0 visible
                elements were found.
                """)
     end
@@ -56,7 +56,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 3 visible elements that matched the css '.test' but
+               Expected to find 3 visible elements that matched the css '.test', but
                only 1 visible element was found.
                """)
     end
@@ -71,7 +71,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find at least 3 visible elements that matched the css
-               '.test' but only 2 visible elements were found.
+               '.test', but only 2 visible elements were found.
                """)
     end
 
@@ -85,7 +85,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find no more than 5 visible elements that matched the css
-               '.test' but 6 visible elements were found.
+               '.test', but 6 visible elements were found.
                """)
     end
 
@@ -99,7 +99,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find some visible elements that matched the css '.test'
-               and return element at index 2 but only 2 visible elements were found.
+               and return element at index 2, but only 2 visible elements were found.
                """)
     end
 
@@ -113,7 +113,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
       assert message ==
                format("""
                Expected to find some visible checkboxes 'test'
-               and return element at index 3 but only 2 visible checkboxes were found.
+               and return element at index 3, but only 2 visible checkboxes were found.
                """)
     end
 
@@ -126,7 +126,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 invisible element that matched the css '.test' but 3
+               Expected to find 1 invisible element that matched the css '.test', but 3
                invisible elements were found.
                """)
     end
@@ -148,7 +148,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible, selected element that matched the css '.test' but 0
+               Expected to find 1 visible, selected element that matched the css '.test', but 0
                visible, selected elements were found.
                """)
     end
@@ -161,7 +161,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible, unselected element that matched the css '.test' but 0
+               Expected to find 1 visible, unselected element that matched the css '.test', but 0
                visible, unselected elements were found.
                """)
     end
@@ -174,7 +174,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element with the text 'test' but 0 visible elements with the text were found.
+               Expected to find 1 visible element with the text 'test', but 0 visible elements with the text were found.
                """)
 
       message =
@@ -184,7 +184,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 2 visible elements with the text 'test' but 0 visible elements with the text were found.
+               Expected to find 2 visible elements with the text 'test', but 0 visible elements with the text were found.
                """)
     end
 
@@ -196,7 +196,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element with the attribute 'value' with value 'test' but 0 visible elements with the attribute were found.
+               Expected to find 1 visible element with the attribute 'value' with value 'test', but 0 visible elements with the attribute were found.
                """)
     end
 
@@ -208,7 +208,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element with the attribute 'an-attribute' with value 'an-attribute-value' but 0 visible elements with the attribute were found.
+               Expected to find 1 visible element with the attribute 'an-attribute' with value 'an-attribute-value', but 0 visible elements with the attribute were found.
                """)
     end
 
@@ -220,7 +220,7 @@ defmodule Wallaby.Query.ErrorMessageTest do
 
       assert message ==
                format("""
-               Expected to find 1 visible element with the attribute 'data-role' with value 'data-attribute-value' but 0 visible elements with the attribute were found.
+               Expected to find 1 visible element with the attribute 'data-role' with value 'data-attribute-value', but 0 visible elements with the attribute were found.
                """)
     end
   end

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -89,6 +89,34 @@ defmodule Wallaby.Query.ErrorMessageTest do
                """)
     end
 
+    test "when the result has too few element for the given `at`" do
+      message =
+        Query.css(".test", at: 2)
+        |> Map.put(:result, [1, 2])
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message ==
+               format("""
+               Expected to find some visible elements that matched the css '.test'
+               and take index 2 but only 2 visible elements were found.
+               """)
+    end
+
+    test "when the result has too few checkboxes for the given `at`" do
+      message =
+        Query.checkbox("test", at: 3)
+        |> Map.put(:result, [1, 2])
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message ==
+               format("""
+               Expected to find some visible checkboxes 'test'
+               and take index 3 but only 2 visible checkboxes were found.
+               """)
+    end
+
     test "when the result is supposed to be invisible" do
       message =
         Query.css(".test", count: 1, visible: false)


### PR DESCRIPTION
1) `assert_has` gave an unexcepted error.
2) `find` gave a wrong error messages always indicating a 0 found count:
"The element at index X is not available because 0 elements..."

This PR provides a more instructive error message for failures. It also
distinguishes between invalid values for `at` and values that are not found.