### PR TITLE
Adds user_agent to endpoint.ex in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ defmodule YourAppWeb.Endpoint do
     plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
   end
 
-  .
-  .
-  .
+  # ...
 
   socket("/live", Phoenix.LiveView.Socket,
     websocket: [connect_info: [:user_agent, session: @session_options]]

--- a/README.md
+++ b/README.md
@@ -127,9 +127,19 @@ defmodule YourAppWeb.Endpoint do
   if sandbox = Application.get_env(:your_app, :sandbox) do
     plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
   end
+
+  .
+  .
+  .
+
+  socket("/live", Phoenix.LiveView.Socket,
+    websocket: [connect_info: [:user_agent, session: @session_options]]
+  )
 ```
 
-Make sure Phoenix is set up to serve endpoints in tests and that the sandbox is enabled:
+It's also important to make sure the `user_agent` is passed in the `connect_info` in order to allow the database and browser session to be wired up correctly.
+
+Then make sure Phoenix is set up to serve endpoints in tests and that the sandbox is enabled:
 
 ```elixir
 # config/test.exs


### PR DESCRIPTION
Part 1 of 2 related bits to ensure you can run your tests in async mode with Wallaby for LiveView, you need the user_agent (at least based on my testing). The other part is in another PR adding the SQL sandbox to the mount.