### PR TITLE
Add sass asset note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,14 @@ There are two common ways to avoid this confusion.
 
 If you're using [`esbuild`](https://hex.pm/packages/esbuild) you can add `esbuild default` to the `test` alias in the mix config file.
 
+If you're using [`dart_sass`](https://hex.pm/packages/dart_sass) you will also need to add `sass default` to the alias.
+
 ```elixir
   defp aliases do
     [
       "test": [
         "esbuild default",
+        "sass default",
         "ecto.create --quiet",
         "ecto.migrate",
         "test",


### PR DESCRIPTION
The **Assets/esbuild** section of the README includes a step on adding `esbuild default` to the `test` alias. This works to recompile javascript files on every run; but it only compiles scss styles on the *first* run, leading to continued confusion when debugging.

To do this, we simply need to add the `sass default` step to the `test` alias.

It's wasn't terribly difficult to figure out, but could save other people the 15 minutes and seems to fit well into this section.