### PR TITLE
fix(chromedriver): Account for Chromium when doing the version matching

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -220,7 +220,7 @@ defmodule Wallaby.Chrome do
           ]
 
         {:unix, :linux} ->
-          ["google-chrome", "chromium"]
+          ["google-chrome", "chromium", "chromium-browser"]
 
         {:win32, :nt} ->
           ["C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"]


### PR DESCRIPTION
We weren't accounting for Chromium when checking the versions of Chrome and ChromeDriver were matching.

@michallepicki can you install this branch and see if it fixes the problem? I was able to confirm that it works with Chromium locally on my MacBook, but haven't tested it manually for Chromium on Linux.

Thanks

Fixes #697 (maybe)
