### PR TITLE
Fixes misreported HTML errors when input labels are changed by CSS

### DIFF
--- a/integration_test/cases/browser/click_test.exs
+++ b/integration_test/cases/browser/click_test.exs
@@ -25,6 +25,25 @@ defmodule Wallaby.Integration.Browser.ClickTest do
 
       assert selected?(page, Query.css("#option2"))
     end
+
+    for {function, button_type} <- [
+          {&Query.checkbox/1, "checkbox"},
+          {&Query.button/1, "button"},
+          {&Query.radio_button/1, "radio"}
+        ] do
+      test "throw an error if label exists for #{button_type} but is not a case match", %{
+        page: page
+      } do
+        assert_raise Wallaby.QueryError,
+                     ~r/matched a label but that label does not find the button/,
+                     fn ->
+                       click(
+                         page,
+                         unquote(function).("misreporting html errors #{unquote(button_type)}")
+                       )
+                     end
+      end
+    end
   end
 
   describe "click/2 with radio buttons (choose replacement)" do

--- a/integration_test/support/pages/forms.html
+++ b/integration_test/support/pages/forms.html
@@ -28,6 +28,21 @@
         Option 1
       </label>
 
+      <label style="text-transform: lowercase">
+        <input type="radio">
+        Misreporting HTML errors radio
+      </label>
+
+      <label style="text-transform: lowercase">
+        <input type="checkbox">
+        Misreporting HTML errors checkbox
+      </label>
+
+      <label style="text-transform: lowercase">
+        <input type="button">
+        Misreporting HTML errors button
+      </label>
+
       <input id="option2" type="radio" name="optionsRadios" value="option2">
 
       <textarea name="text" rows="8" cols="40"></textarea>

--- a/lib/wallaby/query.ex
+++ b/lib/wallaby/query.ex
@@ -254,7 +254,7 @@ defmodule Wallaby.Query do
       method: :radio_button,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label
+      html_validation: :button_type
     }
   end
 
@@ -268,7 +268,7 @@ defmodule Wallaby.Query do
       method: :checkbox,
       selector: selector,
       conditions: build_conditions(opts),
-      html_validation: :bad_label
+      html_validation: :button_type
     }
   end
 

--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -53,6 +53,15 @@ defmodule Wallaby.Query.ErrorMessage do
     """
   end
 
+  def message(%{selector: selector}, :label_does_not_find_button) do
+    """
+    The text '#{selector}' matched a label but that label does not find the button.
+
+    You should ensure you are using the right query function and that the text matches the
+    label's raw HTML exactly (before any CSS transforms are applied).
+    """
+  end
+
   def message(%{selector: selector}, :button_with_bad_type) do
     """
     The text '#{selector}' matched a button but the button has an invalid 'type' attribute.


### PR DESCRIPTION
Hi, first of all, thanks so much for Wallaby - it's so helpful and nice to use!

I've tried to address issue #236 by using the first approach you suggested

> One is to not use the same validate_html logic for checkboxes and radio buttons. This is similar to what we do for buttons

since the other two approaches seemed a bit too involved for my first contribution. If your thinking has evolved since creating the issue and you'd rather take another approach, feel free to let me know; I'm happy to just close this PR.

Thanks!