### PR TITLE
Update `send_keys/2` docs to use correct module

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -660,9 +660,9 @@ defmodule Wallaby.Browser do
 
   ## Example
 
-      iex> Wallaby.Session.send_keys(session, ["Example Text", :enter])
-      iex> Wallaby.Session.send_keys(session, [:enter])
-      iex> Wallaby.Session.send_keys(session, [:shift, :enter])
+      iex> Wallaby.Browser.send_keys(session, ["Example Text", :enter])
+      iex> Wallaby.Browser.send_keys(session, [:enter])
+      iex> Wallaby.Browser.send_keys(session, [:shift, :enter])
 
   ### Note
 


### PR DESCRIPTION
I copy-pasted an example from the `Wallaby.Browser` hexdocs page, only to find that the example for `send_keys/2` was using the wrong module namespace.