### PR TITLE
Surface 'text' condition in css query error message when specified

### DIFF
--- a/lib/wallaby/query/error_message.ex
+++ b/lib/wallaby/query/error_message.ex
@@ -118,9 +118,13 @@ defmodule Wallaby.Query.ErrorMessage do
     "'#{name}' with value '#{value}'"
   end
 
-  def selector(%Query{selector: selector}) do
-    "'#{selector}'"
+  def selector(%Query{selector: selector, conditions: conditions}) do
+    text = with_text(conditions[:text])
+    "'#{selector}'#{text}"
   end
+
+  defp with_text(nil), do: ""
+  defp with_text(text), do: " and contained the text '#{text}'"
 
   defp with_index(:all), do: nil
   defp with_index(at), do: " and return element at index #{at}"

--- a/test/wallaby/query/error_message_test.exs
+++ b/test/wallaby/query/error_message_test.exs
@@ -5,6 +5,34 @@ defmodule Wallaby.Query.ErrorMessageTest do
   alias Wallaby.Query.ErrorMessage
 
   describe "message/1" do
+    test "inclusion of binary 'text' condition when present in css query" do
+      message =
+        Query.css(".lcp-value", text: "322ms")
+        |> Map.put(:result, [])
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message ==
+               format("""
+               Expected to find 1 visible element that matched the css '.lcp-value' and contained the text '322ms', but 0 visible
+               elements were found.
+               """)
+    end
+
+    test "no reference of 'text' condition when it isn't specified" do
+      message =
+        Query.css(".lcp-value")
+        |> Map.put(:result, [])
+        |> ErrorMessage.message(:not_found)
+        |> format
+
+      assert message ==
+               format("""
+               Expected to find 1 visible element that matched the css '.lcp-value', but 0 visible
+               elements were found.
+               """)
+    end
+
     test "when the results are more than the expected count" do
       message =
         Query.css(".test", count: 1)


### PR DESCRIPTION
## Summary
This pull request surfaces the `text` condition value when it's specified in CSS queries, and leaves the existing error message as-is when the condition _isn't_ specified.

## Motivation

I frequently build out css queries using the `text` condition (in combination with the base css selector of the query). Sometimes I would get failures where the element selector was found in the application UI but failed due the `text` condition, but in those cases the error message would only reference the selector, which would lead me to think that the element hadn't been present at all. 

These cases usually led me to open the screenshots and see the element present in the UI and realize my error—usually a case mismatch or outright typo🤦🏻‍♂️—and it's happened to me enough that I figured the lib could and should specify this condition in the error.

When the text-condition _isn't_ specified, we leave the existing error message as-is so as to not confuse devs.

## Before

![image](https://user-images.githubusercontent.com/4386645/200941560-29d0595a-8fb0-4de5-9425-9388e804d76b.png)

## After

![image](https://user-images.githubusercontent.com/4386645/200941198-7fe4518e-e419-413d-af73-be6b97b9eefe.png)


