### PR TITLE
Check if ExUnit is available before setting up after suite calls

### DIFF
--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -36,16 +36,18 @@ defmodule Wallaby.SessionStore do
     Process.flag(:trap_exit, true)
     tid = :ets.new(name, opts)
 
-    Application.ensure_all_started(:ex_unit)
+    if Code.ensure_loaded?(ExUnit) do
+      Application.ensure_all_started(:ex_unit)
 
-    ExUnit.after_suite(fn _ ->
-      try do
-        :ets.tab2list(tid)
-        |> Enum.each(&delete_sessions/1)
-      rescue
-        _ -> nil
-      end
-    end)
+      ExUnit.after_suite(fn _ ->
+        try do
+          :ets.tab2list(tid)
+          |> Enum.each(&delete_sessions/1)
+        rescue
+          _ -> nil
+        end
+      end)
+    end
 
     {:ok, %{ets_table: tid}}
   end


### PR DESCRIPTION
I have a use case using Wallaby to control the browser outside the test suite and this code seems to be the only issue preventing that. It auto tries to call ExUnit when it's not available, maybe only execute ExUnit hooks if it's available.

Open to solving this another way if there are recommendations.