### PR TITLE
Update README's AllowEctoSandbox config for liveview 0.18.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ In order to test Phoenix LiveView (as of [version 0.17.7](https://github.com/pho
 ```elixir
 defmodule MyApp.Hooks.AllowEctoSandbox do
   import Phoenix.LiveView
+  import Phoenix.Component
 
   def on_mount(:default, _params, _session, socket) do
     allow_ecto_sandbox(socket)


### PR DESCRIPTION
  - `assign_new/3` was one of several functions moved to `Phoenix.Component` in the phoenix_live_view 0.18.0 release
  - we still need the `import Phoenix.LiveView` due to other funcs called in the `AllowEctoSandbox` module