### PR TITLE
Shadow dom

### DIFF
--- a/integration_test/cases/browser/shadow_dom_test.exs
+++ b/integration_test/cases/browser/shadow_dom_test.exs
@@ -13,10 +13,11 @@ defmodule Wallaby.Integration.Browser.ShadowDomTest do
   end
 
   test "can find a shadow root", %{session: session} do
-    element =
+    shadow_root =
       session
-      |> find_shadow(Query.css("shadow-test"))
+      |> find(Query.css("shadow-test"))
+      |> shadow_root()
 
-    assert element
+    assert shadow_root
   end
 end

--- a/integration_test/cases/browser/shadow_dom_test.exs
+++ b/integration_test/cases/browser/shadow_dom_test.exs
@@ -20,4 +20,21 @@ defmodule Wallaby.Integration.Browser.ShadowDomTest do
 
     assert shadow_root
   end
+
+  test "can find stuff within da shadow dom", %{session: session} do
+    element =
+      session
+      |> find(Query.css("shadow-test"))
+      |> shadow_root()
+      |> find(Query.css("#in-shadow"))
+  end
+
+  test "can click stuff within da shadow dom", %{session: session} do
+    element =
+      session
+      |> find(Query.css("shadow-test"))
+      |> shadow_root()
+      |> click(Query.css("button"))
+  end
+
 end

--- a/integration_test/cases/browser/shadow_dom_test.exs
+++ b/integration_test/cases/browser/shadow_dom_test.exs
@@ -1,0 +1,22 @@
+defmodule Wallaby.Integration.Browser.ShadowDomTest do
+
+  use Wallaby.Integration.SessionCase, async: true
+
+  import Wallaby.Query, only: [css: 1]
+
+  setup %{session: session} do
+    page =
+      session
+      |> visit("shadow_dom.html")
+
+    {:ok, page: page}
+  end
+
+  test "can find a shadow root", %{session: session} do
+    element =
+      session
+      |> find_shadow(Query.css("shadow-test"))
+
+    assert element
+  end
+end

--- a/integration_test/support/pages/shadow_dom.html
+++ b/integration_test/support/pages/shadow_dom.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+    <script>
+      window.customElements.define('shadow-test', class extends HTMLElement() {
+        connecteCallback() {
+          this.attachShadow({mode: 'open'});
+          this.shadowRoot.innerHTML = '<div id="in_shadow">I am in shadow</div>';
+        }
+      });
+    </script>
+  </head>
+
+  <body>
+    <div id="outside_shadow">I am out of shadow</div>
+    <shadow-test></shadow-test>
+  </body>
+</html>

--- a/integration_test/support/pages/shadow_dom.html
+++ b/integration_test/support/pages/shadow_dom.html
@@ -1,12 +1,13 @@
 <html>
   <head>
     <script>
-      window.customElements.define('shadow-test', class extends HTMLElement() {
-        connecteCallback() {
+      class ShadowTestElement extends HTMLElement {
+        connectedCallback() {
           this.attachShadow({mode: 'open'});
           this.shadowRoot.innerHTML = '<div id="in_shadow">I am in shadow</div>';
         }
-      });
+      }
+      window.customElements.define('shadow-test', ShadowTestElement);
     </script>
   </head>
 

--- a/integration_test/support/pages/shadow_dom.html
+++ b/integration_test/support/pages/shadow_dom.html
@@ -4,7 +4,10 @@
       class ShadowTestElement extends HTMLElement {
         connectedCallback() {
           this.attachShadow({mode: 'open'});
-          this.shadowRoot.innerHTML = '<div id="in_shadow">I am in shadow</div>';
+          this.shadowRoot.innerHTML = `
+            <div id="in-shadow">I am in shadow</div>
+            <button>Hi!</button>
+          `;
         }
       }
       window.customElements.define('shadow-test', ShadowTestElement);

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1013,7 +1013,6 @@ defmodule Wallaby.Browser do
   end
 
   def shadow_root(%{driver: driver} = element) do
-    IO.inspect(driver)
     driver.shadow_root(element)
   end
 

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -999,6 +999,26 @@ defmodule Wallaby.Browser do
     parent
   end
 
+  def find_shadow(%{driver: driver}, query) do
+    retry(fn ->
+      try do
+        with {:ok, query} <- Query.validate(query),
+             compiled_query <- Query.compile(query),
+             {:ok, elements} <- driver.find_shadow(parent, compiled_query),
+             {:ok, elements} <- validate_visibility(query, elements),
+             {:ok, elements} <- validate_text(query, elements),
+             {:ok, elements} <- validate_selected(query, elements),
+             {:ok, elements} <- validate_count(query, elements),
+             {:ok, elements} <- do_at(query, elements) do
+          elements
+        end
+      rescue
+        StaleReferenceError ->
+          {:error, :stale_reference}
+      end
+    end)
+  end
+
   @doc """
   Finds all of the DOM elements that match the CSS selector. If no elements are
   found then an empty list is immediately returned. This is equivalent to calling

--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -999,26 +999,6 @@ defmodule Wallaby.Browser do
     parent
   end
 
-  def find_shadow(%{driver: driver}, query) do
-    retry(fn ->
-      try do
-        with {:ok, query} <- Query.validate(query),
-             compiled_query <- Query.compile(query),
-             {:ok, elements} <- driver.find_shadow(parent, compiled_query),
-             {:ok, elements} <- validate_visibility(query, elements),
-             {:ok, elements} <- validate_text(query, elements),
-             {:ok, elements} <- validate_selected(query, elements),
-             {:ok, elements} <- validate_count(query, elements),
-             {:ok, elements} <- do_at(query, elements) do
-          elements
-        end
-      rescue
-        StaleReferenceError ->
-          {:error, :stale_reference}
-      end
-    end)
-  end
-
   @doc """
   Finds all of the DOM elements that match the CSS selector. If no elements are
   found then an empty list is immediately returned. This is equivalent to calling
@@ -1030,6 +1010,11 @@ defmodule Wallaby.Browser do
       parent,
       %Query{query | conditions: Keyword.merge(query.conditions, count: nil, minimum: 0)}
     )
+  end
+
+  def shadow_root(%{driver: driver} = element) do
+    IO.inspect(driver)
+    driver.shadow_root(element)
   end
 
   @doc """

--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -531,6 +531,9 @@ defmodule Wallaby.Chrome do
   def find_elements(session_or_element, compiled_query),
     do: delegate(:find_elements, session_or_element, [compiled_query])
 
+  def find_shadow(session_or_element, compiled_query),
+    do: delegate(:find_shadow, session_or_element, [compiled_query])
+
   @doc false
   def send_keys(session_or_element, keys), do: delegate(:send_keys, session_or_element, [keys])
   @doc false

--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -410,6 +410,9 @@ defmodule Wallaby.Chrome do
   defdelegate accept_prompt(session, input, fun), to: WebdriverClient
   @doc false
   defdelegate dismiss_prompt(session, fun), to: WebdriverClient
+
+  defdelegate shadow_root(element), to: WebdriverClient
+
   @doc false
   defdelegate parse_log(log), to: Wallaby.Chrome.Logger
 
@@ -530,9 +533,6 @@ defmodule Wallaby.Chrome do
   @doc false
   def find_elements(session_or_element, compiled_query),
     do: delegate(:find_elements, session_or_element, [compiled_query])
-
-  def find_shadow(session_or_element, compiled_query),
-    do: delegate(:find_shadow, session_or_element, [compiled_query])
 
   @doc false
   def send_keys(session_or_element, keys), do: delegate(:send_keys, session_or_element, [keys])

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -181,6 +181,12 @@ defmodule Wallaby.Driver do
               {:ok, [Element.t()]} | {:error, reason}
 
   @doc """
+  Invoked to find child elements of the given session/element.
+  """
+  @callback find_shadow(Session.t() | Element.t(), Query.compiled()) ::
+              {:ok, Element.t()} | {:error, reason}
+
+  @doc """
   Invoked to execute JavaScript in the browser.
   """
   @callback execute_script(Session.t() | Element, String.t(), [any]) ::

--- a/lib/wallaby/driver.ex
+++ b/lib/wallaby/driver.ex
@@ -181,9 +181,9 @@ defmodule Wallaby.Driver do
               {:ok, [Element.t()]} | {:error, reason}
 
   @doc """
-  Invoked to find child elements of the given session/element.
+  Invoked to find shadow root of given element
   """
-  @callback find_shadow(Session.t() | Element.t(), Query.compiled()) ::
+  @callback shadow_root(Element.t()) ::
               {:ok, Element.t()} | {:error, reason}
 
   @doc """

--- a/lib/wallaby/webdriver_client.ex
+++ b/lib/wallaby/webdriver_client.ex
@@ -13,6 +13,7 @@ defmodule Wallaby.WebdriverClient do
           | Session.t()
 
   @web_element_identifier "element-6066-11e4-a52e-4f735466cecf"
+  @shadow_root_identifier "shadow-6066-11e4-a52e-4f735466cecf"
 
   @button_mapping %{left: 0, middle: 1, right: 2}
 
@@ -58,6 +59,13 @@ defmodule Wallaby.WebdriverClient do
          {:ok, elements} <- Map.fetch(resp, "value"),
          elements <- Enum.map(elements || [], &cast_as_element(parent, &1)),
          do: {:ok, elements}
+  end
+
+  def shadow_root(element) do
+    with {:ok, resp} <- request(:get, element.url <> "/shadow"),
+         {:ok, shadow_root} <- Map.fetch(resp, "value") do
+      cast_as_element(element, shadow_root)
+    end
   end
 
   @doc """
@@ -706,6 +714,16 @@ defmodule Wallaby.WebdriverClient do
       id: id,
       session_url: parent.session_url,
       url: parent.session_url <> "/element/#{id}",
+      parent: parent,
+      driver: parent.driver
+    }
+  end
+
+  defp cast_as_element(parent, %{@shadow_root_identifier => id}) do
+    %Wallaby.Element{
+      id: id,
+      session_url: parent.session_url,
+      url: parent.session_url <> "/shadow/#{id}",
       parent: parent,
       driver: parent.driver
     }

--- a/lib/wallaby/webdriver_client.ex
+++ b/lib/wallaby/webdriver_client.ex
@@ -49,6 +49,18 @@ defmodule Wallaby.WebdriverClient do
   end
 
   @doc """
+  Finds an element on the page for a session. If an element is provided then
+  the query will be scoped to within that element.
+  """
+  @spec find_elements(Session.t() | Element.t(), Query.compiled()) :: {:ok, [Element.t()]}
+  def find_elements(parent, locator) do
+    with {:ok, resp} <- request(:post, parent.url <> "/elements", to_params(locator)),
+         {:ok, elements} <- Map.fetch(resp, "value"),
+         elements <- Enum.map(elements || [], &cast_as_element(parent, &1)),
+         do: {:ok, elements}
+  end
+
+  @doc """
   Sets the value of an element.
   """
   @spec set_value(Element.t(), String.t()) :: {:ok, nil} | {:error, Driver.reason()}


### PR DESCRIPTION
@mhanberg this is what we ended up with. We added a `shadow_root/1` function on `Wallaby.Browser` that takes an element and narrows the scope to the shadow root of the element. This seems to line up really nicely with what webdriver wants and pretty much lets everything "just work" in what seems like a nice way IMO. Curious to hear your thoughts. If you think it's ok I'll add docs and get it mergable