### PR TITLE
execute_cdp_command added

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -527,6 +527,29 @@ defmodule Wallaby.Chrome do
     end
   end
 
+  @doc """
+  Chromium specific function to execute CDP (Chrome Devtools Protocol) commands
+  https://chromedevtools.github.io/devtools-protocol/
+  """
+  @spec execute_cdp_command(Wallaby.Session.t(), String.t(), map()) :: {:ok, any()} | {:error, any()}
+  def execute_cdp_command(session, command, params) do
+    url = "#{session.session_url}/goog/cdp/execute"
+    case Wallaby.HTTPClient.request(:post, url, %{cmd: command, params: params}) do
+      {:ok, %{"status" => 0, "value" => value}} ->
+        {:ok, value}
+
+      {:ok, %{"status" => status} = response} ->
+        {:error, {:bad_status, status, response}}
+
+      {:ok, %{}} ->
+        # Value not presend
+        :error
+
+      other ->
+        other
+    end
+  end
+
   @doc false
   def find_elements(session_or_element, compiled_query),
     do: delegate(:find_elements, session_or_element, [compiled_query])


### PR DESCRIPTION
Please help me write the test.

I was able to reproduce that this change worked correctly with
```
echo "HTTP/1.1 200 OK\r\nServer: netcat\r\n\r\n" | nc -l 9999
```
And then
```elixir
iex> {:ok, session} = Wallaby.start_session()
iex> Wallaby.Chrome.execute_cdp_command(session, "Network.setUserAgentOverride", %{"userAgent" => "hey"})
iex> Wallaby.visit(session, "http://localhost:9999/")
```

And then netcat returned
```
GET /x HTTP/1.1
Host: localhost:9999
Connection: keep-alive
Upgrade-Insecure-Requests: 1
User-Agent: hey
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Sec-Fetch-Site: none
Sec-Fetch-Mode: navigate
Sec-Fetch-User: ?1
Sec-Fetch-Dest: document
Accept-Encoding: gzip, deflate, br
Accept-Language: en-US
```