### PR TITLE
Chrome headless and binary opts can be passed in @sessions

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -362,8 +362,8 @@ defmodule Wallaby.Chrome do
     :wallaby
     |> Application.get_env(:chromedriver, [])
     |> Keyword.get(:capabilities, default_capabilities(opts))
-    |> put_headless_config()
-    |> put_binary_config()
+    |> put_headless_config(opts)
+    |> put_binary_config(opts)
   end
 
   @spec wait_until_ready!(timeout) :: :ok | no_return
@@ -576,8 +576,8 @@ defmodule Wallaby.Chrome do
     }
   end
 
-  defp put_headless_config(capabilities) do
-    headless? = Application.get_env(:wallaby, :chromedriver, []) |> Keyword.get(:headless)
+  defp put_headless_config(capabilities, opts) do
+    headless? = resolve_opt(opts, :headless)
 
     capabilities
     |> update_unless_nil(:args, headless?, fn args ->
@@ -590,13 +590,20 @@ defmodule Wallaby.Chrome do
     end)
   end
 
-  defp put_binary_config(capabilities) do
-    binary_path = Application.get_env(:wallaby, :chromedriver, []) |> Keyword.get(:binary)
+  defp put_binary_config(capabilities, opts) do
+    binary_path = resolve_opt(opts, :binary)
 
     capabilities
     |> update_unless_nil(:binary, binary_path, fn _ ->
       binary_path
     end)
+  end
+
+  defp resolve_opt(opts, key) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} -> value
+      :error -> Application.get_env(:wallaby, :chromedriver, []) |> Keyword.get(key)
+    end
   end
 
   defp update_unless_nil(capabilities, _key, nil, _updater), do: capabilities

--- a/lib/wallaby/feature.ex
+++ b/lib/wallaby/feature.ex
@@ -69,11 +69,11 @@ defmodule Wallaby.Feature do
   end
   ```
 
-  If you need to change the capabilities sent to the session for a specific feature, you can assign `@sessions` to a list of keyword lists of the options to be passed to `Wallaby.start_session/1`. This will start the number of sessions equal to the size of the list.
+  If you need to change the headless mode, binary path, or capabilities sent to the session for a specific feature, you can assign `@sessions` to a list of keyword lists of the options to be passed to `Wallaby.start_session/1`. This will start the number of sessions equal to the size of the list.
 
   ```
   @sessions [
-    [capabilities: %{}]
+    [headless: false, binary: "some_path", capabilities: %{}]
   ]
   feature "test with different capabilities", %{session: session} do
     # ...


### PR DESCRIPTION
This makes it possible to override `headless` and `binary` for a particular test, e.g., 

```elixir
@sessions [[headless: false]]
feature "my feature", %{session: session} do 
  ...
end
```