### PR TITLE
Update README to Avoid Elixir Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ It's important that this is at the top of `endpoint.ex` before any other plugs.
 defmodule YourAppWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :your_app
 
-  if sandbox = Application.get_env(:your_app, :sandbox) do
+  if sandbox = Application.compile_env(:your_app, :sandbox, false) do
     plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
   end
 


### PR DESCRIPTION
A warning is issued for use of `get_env/2` used outside of a module. The warning suggests using `compile_env/3` instead.

This change updates the documentation to conform to this suggestion and remove the warning, resulting in a cleaner and more modern setup for `wallaby`.

Resolves [#761](https://github.com/elixir-wallaby/wallaby/issues/761)