### PR TITLE
Trapping process causes conflict with created users

### DIFF
--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -33,7 +33,7 @@ defmodule Wallaby.SessionStore do
       if(name == :session_store, do: [:named_table], else: []) ++
         [:set, :public, read_concurrency: true]
 
-    Process.flag(:trap_exit, true)
+    # Process.flag(:trap_exit, true)
     tid = :ets.new(name, opts)
 
     Application.ensure_all_started(:ex_unit)
@@ -89,6 +89,14 @@ defmodule Wallaby.SessionStore do
     :ets.delete(state.ets_table, {ref, session.id, pid})
 
     emit(%{module: __MODULE__, name: :DOWN, metadata: %{monitored_session: session}})
+
+    {:noreply, state}
+  end
+
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    # Fallback - Handle the normal exit signal appropriately
+    # Just log it or ignore as per the requirement
+    Logger.info("Received normal exit signal from linked process")
 
     {:noreply, state}
   end

--- a/lib/wallaby/session_store.ex
+++ b/lib/wallaby/session_store.ex
@@ -33,7 +33,7 @@ defmodule Wallaby.SessionStore do
       if(name == :session_store, do: [:named_table], else: []) ++
         [:set, :public, read_concurrency: true]
 
-    # Process.flag(:trap_exit, true)
+    Process.flag(:trap_exit, false)
     tid = :ets.new(name, opts)
 
     Application.ensure_all_started(:ex_unit)
@@ -89,14 +89,6 @@ defmodule Wallaby.SessionStore do
     :ets.delete(state.ets_table, {ref, session.id, pid})
 
     emit(%{module: __MODULE__, name: :DOWN, metadata: %{monitored_session: session}})
-
-    {:noreply, state}
-  end
-
-  def handle_info({:EXIT, _pid, :normal}, state) do
-    # Fallback - Handle the normal exit signal appropriately
-    # Just log it or ignore as per the requirement
-    Logger.info("Received normal exit signal from linked process")
 
     {:noreply, state}
   end


### PR DESCRIPTION
When attempting to create a user to login during Wallaby test, this error appears:

`Wallaby.SessionStore.handle_info({:EXIT, #PID<0.984.0>, :normal}, %{ets_table: :session_store})`

Switching Process.flag(:trap_process, true) to Process.flag(:trap_process, false) solves problem.