### PR TITLE
Address deprecation; prefer ExUnit.Case.register_test/6

### DIFF
--- a/lib/wallaby/feature.ex
+++ b/lib/wallaby/feature.ex
@@ -121,8 +121,17 @@ defmodule Wallaby.Feature do
     context = Macro.escape(context)
     contents = Macro.escape(contents, unquote: true)
 
-    quote bind_quoted: [context: context, contents: contents, message: message] do
-      name = ExUnit.Case.register_test(__ENV__, :feature, message, [:feature])
+    %{module: mod, file: file, line: line} = __CALLER__
+
+    quote bind_quoted: [
+            mod: mod,
+            file: file,
+            line: line,
+            context: context,
+            contents: contents,
+            message: message
+          ] do
+      name = ExUnit.Case.register_test(mod, file, line, :feature, message, [:feature])
 
       def unquote(name)(unquote(context)), do: unquote(contents)
     end


### PR DESCRIPTION
  - `ExUnit.Case.register_test/6` has been available since Elixir 1.11.0, and now triggers deprecation warnings as of Elixir 1.17. This would be a breaking change if the intention is to support Elixir versions prior to 1.11, but I think we're all good on that front, given the existing CI version matrix