### PR TITLE
Fix unhandled alerts not being properly ignored

### DIFF
--- a/lib/wallaby/httpclient.ex
+++ b/lib/wallaby/httpclient.ex
@@ -165,19 +165,14 @@ defmodule Wallaby.HTTPClient do
 
   defp coerce_json_message(%{"value" => %{"message" => message} = value} = response) do
     value =
-      case Regex.named_captures(~r/(?<type>.*): (?<payload>{.*})\n.*/, message) do
-        %{"payload" => payload, "type" => type} ->
-          message =
-            case Jason.decode(payload) do
-              {:ok, message} -> message
-              _ -> payload
-            end
-
-          %{
-            "message" => message,
-            "type" => type
-          }
-
+      with %{"payload" => payload, "type" => type} <-
+             Regex.named_captures(~r/(?<type>.*): (?<payload>{.*})\n.*/, message),
+           {:ok, message} <- Jason.decode(payload) do
+        %{
+          "message" => message,
+          "type" => type
+        }
+      else
         _ ->
           value
       end


### PR DESCRIPTION
This is an improvement over #778. By falling back to the full message value from Chromedriver, we can correctly get the `:unexpected_alert` condition to match on the bizarre, not-quite-JSON message from Chromedriver like:

```
    "message" => "unexpected alert open: {Alert text : Error loading data, please refresh and try again}\n  (Session info: chrome-headless-shell=125.0.6422.142)\n  (Driver info: chromedriver=125.0.6422.78 (14db42ec38aded3304a3e624a0a038e02956b87e-refs/branch-heads/6422@{#1088}),platform=Mac OS X 14.5.0 x86_64)"
```

Applying this patch to my local copy, my default-configured Chromedriver correctly ignores the alert and my tests that passed on v0.36.6 again pass.