### PR TITLE
feat: allow to slow down browser actions

### DIFF
--- a/lib/wallaby/chrome.ex
+++ b/lib/wallaby/chrome.ex
@@ -397,6 +397,12 @@ defmodule Wallaby.Chrome do
 
   defp delegate(fun, element_or_session, args \\ []) do
     check_logs!(element_or_session, fn ->
+      delay = Application.get_env(:wallaby, :slow_down, 0)
+
+      if delay > 0 do
+        :timer.sleep(delay)
+      end
+
       apply(WebdriverClient, fun, [element_or_session | args])
     end)
   end


### PR DESCRIPTION
For cases mentioned in https://github.com/elixir-wallaby/wallaby/issues/337 and in order to enable the developer to watch their test execute in a comprehensible way while developing, I've added the `:slow_down` config option to implement that feature.

I'm not sure how to test this, but open for suggestions and recommendations.