### PR TITLE
Make assert_text/3 pipable

### DIFF
--- a/lib/wallaby/browser.ex
+++ b/lib/wallaby/browser.ex
@@ -1136,6 +1136,8 @@ defmodule Wallaby.Browser do
     parent
     |> find(query)
     |> assert_text(text)
+    
+    parent
   end
 
   def assert_text(parent, text) when is_binary(text) do


### PR DESCRIPTION
Currently, assert_text/3 returns a %Wallaby.Element{} struct matched inside the find(parent, query) call, instead of the original parent passed to assert_text/3 as specified in the function's doc and spec.