### PR TITLE
Only spawn a browser when using the `feature` macro, not normal `test`s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     - name: Run Tests
       run: mix test || mix test --failed || mix test --failed
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Selenium Logs
@@ -210,7 +210,7 @@ jobs:
     - name: Run Tests
       run: mix test || mix test --failed || mix test --failed
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Selenium Logs
@@ -250,7 +250,7 @@ jobs:
     - name: Run Tests
       run: mix test || mix test --failed || mix test --failed
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: Selenium Logs

--- a/integration_test/cases/feature/use_feature_test.exs
+++ b/integration_test/cases/feature/use_feature_test.exs
@@ -34,4 +34,8 @@ defmodule Wallaby.Integration.Browser.UseFeatureTest do
   feature "reads capabilities from session attribute", %{session: %{capabilities: capabilities}} do
     assert capabilities.test == @expected_capabilities.test
   end
+
+  test "does not set up a session for non-feature tests", context do
+    refute is_map_key(context, :session)
+  end
 end

--- a/lib/wallaby/feature.ex
+++ b/lib/wallaby/feature.ex
@@ -23,14 +23,7 @@ defmodule Wallaby.Feature do
       import Wallaby.Feature
 
       setup context do
-        # Only set up a session if this is a feature test (using the `feature` macro).
-        feature_test? = context[:feature] == true
-
-        # If you have `use Wallaby.Feature` at the top of your test module,
-        # then also within a `describe` block, we only want to set up one session.
-        already_has_session? = is_map_key(context, :session)
-
-        if feature_test? and not already_has_session? do
+        if context[:test_type] == :feature do
           metadata = unquote(__MODULE__).Utils.maybe_checkout_repos(context[:async])
 
           start_session_opts =


### PR DESCRIPTION
This fixes an unintended behavior where having `use Wallaby.Feature` at the top of your module would cause a browser to be spawned for every test in the module, not just `feature` tests. The result is that if you had a large test module, most of which used the normal `test` macro and one of which used the `feature` macro, every test would take a minimum of a third of a second or more.

~I also took the liberty to check and see in the `setup` block if we already had a `:session`, and if so, avoid spawning a second. I don't *think* anyone was relying on the behavior where a second browser was being spawned if you had `use Wallaby.Feature` at both the top of the module and a `describe` block.~

Resolves #794