### PR TITLE
Update configuration example for umbrella apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ It's important that this is at the top of `endpoint.ex` before any other plugs.
 defmodule YourAppWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :your_app
 
-  if sandbox = Application.compile_env(:your_app, :sandbox, false) do
-    plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
+  if Application.compile_env(:your_app, :sandbox, false) do
+    plug Phoenix.Ecto.SQL.Sandbox
   end
 
   # ...
@@ -299,8 +299,8 @@ If you're testing an umbrella application containing a Phoenix application for t
 defmodule MyWebApp.Endpoint do
   use Phoenix.Endpoint, otp_app: :my_web_app
 
-  if sandbox = Application.compile_env(:my_persistence_app, :sandbox, false) do
-    plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
+  if Application.compile_env(:my_persistence_app, :sandbox, false) do
+    plug Phoenix.Ecto.SQL.Sandbox
   end
 ```
 

--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ If you're testing an umbrella application containing a Phoenix application for t
 defmodule MyWebApp.Endpoint do
   use Phoenix.Endpoint, otp_app: :my_web_app
 
-  if Application.get_env(:my_persistence_app, :sql_sandbox) do
-    plug Phoenix.Ecto.SQL.Sandbox
+  if sandbox = Application.compile_env(:my_persistence_app, :sandbox, false) do
+    plug Phoenix.Ecto.SQL.Sandbox, sandbox: sandbox
   end
 ```
 


### PR DESCRIPTION
💁 This change updates the configuration example for umbrella apps using Elixir >= 1.14. Calling `Application.get_env/3` and friends in the module body was [hard deprecated in Elixir 1.14.0](https://github.com/elixir-lang/elixir/blob/v1.14/CHANGELOG.md#4-hard-deprecations) and using it will raise errors like the following:
```
==> my_web_app
Compiling 62 files (.ex)
    warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
    │
  6 │   if Application.get_env(:my_persistence_app, :sql_sandbox) do
    │                  ~
    │
    └─ lib/my_web_app/endpoint.ex:6:18: MyWebApp.Endpoint (module)
```

Related to:
- https://github.com/elixir-wallaby/wallaby/issues/761
- https://github.com/elixir-wallaby/wallaby/pull/762